### PR TITLE
BUGFIX: Update edges on `input_schema` or `output_schema` key changes

### DIFF
--- a/frontend/src/components/nodes/nodeSidebar/SchemaEditor.jsx
+++ b/frontend/src/components/nodes/nodeSidebar/SchemaEditor.jsx
@@ -1,8 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Button, Input, Select, SelectItem } from '@nextui-org/react';
 import { Icon } from '@iconify/react';
 import { useDispatch } from 'react-redux';
-import { deleteEdgeByHandle } from '../../../store/flowSlice'; // Import the deleteEdge action
+import { deleteEdgeByHandle, updateEdgesOnHandleRename } from '../../../store/flowSlice'; // Import the deleteEdge action
 
 const SchemaEditor = ({ jsonValue = {}, onChange, options = [], disabled = false, schemaType = 'input_schema', nodeId }) => {
   const [newKey, setNewKey] = useState('');
@@ -59,6 +59,14 @@ const SchemaEditor = ({ jsonValue = {}, onChange, options = [], disabled = false
     delete updatedJson[oldKey];
 
     onChange(updatedJson);
+    if (newKey && oldKey) {
+      dispatch(updateEdgesOnHandleRename({
+        nodeId,
+        oldHandleId: oldKey,
+        newHandleId: newKey,
+        schemaType,
+      }))
+    }
     setEditingField(null);
   };
 


### PR DESCRIPTION
- Added functionality to dispatch an action for updating edges when a handle is renamed in the SchemaEditor component.
- Imported the new action `updateEdgesOnHandleRename` from the flowSlice.
- Ensured that the edges are updated only if both new and old keys are provided.