### PR TITLE
Feat/ollama integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,9 +40,15 @@ NGINX_PORT=6080
 # ======================
 # Ollama Configuration
 # ======================
-# Ollama models will show up if the 
-# following environment variable is set
 
-# OLLAMA_BASE_URL=your_ollama_base_url
+# NOTE:
+# if the ollama service is running on port 11434 of the host machine,
+# then use http://host.docker.internal:11434 as the base url
+# if the ollama service is running on a different host, use the ip address or domain name of the host
+
+# Also make sure the ollama service is configured to accept requests. 
+# This can be done setting OLLAMA_HOST=0.0.0.0 environment variable before launching the ollama service.
+
+# OLLAMA_BASE_URL=http://host.docker.internal:11434 
 
 # ======================

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,48 @@
+# ======================
+# Core Configuration
+# ======================
+
+# Backend Configuration
+BACKEND_PORT=8000
+BACKEND_HOST=0.0.0.0
+DEBUG=False
+
+# Frontend Configuration
+FRONTEND_PORT=3000
+FRONTEND_HOST=0.0.0.0
+
+# Nginx Configuration
+# This is the port that will be used to access the application
+NGINX_PORT=6080
+
+# ======================
+# Database Settings
+# ======================
+# leave these commented out if you wish to 
+# use default sqlite database
+
+# DB_NAME=your_db_name
+# DB_USER=your_db_user
+# DB_PASSWORD=your_db_password
+# DB_HOST=localhost
+# DB_PORT=5432
+
+
+# ======================
+# Model Provider API Keys
+# ======================
+
+# OPENAI_API_KEY=your_openai_api_key
+# GEMINI_API_KEY=your_gemini_api_key
+# ANTHROPIC_API_KEY=your_anthropic_api_key
+
+
+# ======================
+# Ollama Configuration
+# ======================
+# Ollama models will show up if the 
+# following environment variable is set
+
+# OLLAMA_BASE_URL=your_ollama_base_url
+
+# ======================

--- a/README.md
+++ b/README.md
@@ -75,12 +75,50 @@ You can get PySpur up and running in three quick steps.
 
 Set up is completed. Click on "New Spur" to create a workflow, or start with one of the stock templates.
 
+# Using PySpur with Ollama (Local Models)
+
+PySpur can work with local models served using Ollama.
+
+Steps to configure PySpur to work with Ollama running on the same host.
+
+### 1. Configure Ollama
+To ensure Ollama API is reachable from PySpur, we need to start the Ollama service with environment variable `OLLAMA_HOST=0.0.0.0` . This allows requests coming from PySpur docker's bridge network to get through to Ollama. 
+An easy way to do this is to launch the ollama service with the following command:
+```
+OLLAMA_HOST="0.0.0.0" ollama serve
+```
+
+### 2. Update the PySpur .env file
+Next up we need to update the `OLLAMA_BASE_URL` environment value in the `.env` file.
+If your Ollama port is 11434 (the default port), then the entry in `.env` file should look like this:
+```
+OLLAMA_BASE_URL=http://host.docker.internal:11434 
+```
+(Please make sure that there is no trailing slash in the end!)
+
+In PySpur's set up, `host.docker.internal` refers to the host machine where both PySpur and Ollama are running.
+
+### 3. Launch the PySpur app
+Follow the usual steps to launch the PySpur app, starting with the command:
+```
+docker compose up --build -d
+```
+
+### 4. Using Ollama models in the app
+You will be able to select Ollama models [`ollama/llama3.2`, `ollama/llama3`, ...] from the sidebar for LLM nodes.
+Please make sure the model you select is explicitly downloaded in ollama. That is, you will need to manually manage these models via ollama. To download a model you can simply run `ollama pull <model-name>`.
+
+## Note on supported models
+PySpur only works with models that support structured-output and json mode. Most newer models should be good, but it would still be good to confirm this from Ollama documentation for the model you wish to use.
+
+
 # 🗺️ Roadmap
 
 - [X] Canvas
 - [X] Async/Batch Execution
 - [X] Evals
 - [X] Spur API
+- [x] Support Ollama
 - [ ] New Nodes
     - [X] LLM Nodes
     - [X] If-Else

--- a/backend/app/api/key_management.py
+++ b/backend/app/api/key_management.py
@@ -10,11 +10,10 @@ load_dotenv(".env")
 router = APIRouter()
 
 
-DEFAULT_KEYS = [
+MODEL_PROVIDER_KEYS = [
     {"name": "OPENAI_API_KEY", "value": ""},
     {"name": "ANTHROPIC_API_KEY", "value": ""},
     {"name": "GEMINI_API_KEY", "value": ""},
-    {"name": "OLLAMA_API_BASE", "value": "http://localhost:11434"},
 ]
 
 
@@ -65,11 +64,9 @@ def mask_key_value(value: str) -> str:
 @router.get("/", description="Get a list of all environment variable names")
 async def list_api_keys():
     """
-    Returns a list of all environment variable names without revealing their values.
+    Returns a list of all model provider keys 
     """
-    env_vars = get_all_env_variables()
-    all_keys = set([k["name"] for k in DEFAULT_KEYS]) | set(env_vars.keys())
-    return {"keys": list(all_keys)}
+    return [k["name"] for k in MODEL_PROVIDER_KEYS]
 
 
 @router.get(
@@ -80,12 +77,11 @@ async def get_api_key(name: str):
     Returns the masked value of the specified environment variable.
     Requires authentication.
     """
+    if name not in [k["name"] for k in MODEL_PROVIDER_KEYS]:
+            raise HTTPException(status_code=404, detail="Key not found")
     value = get_env_variable(name)
     if value is None:
-        if name not in [k["name"] for k in DEFAULT_KEYS]:
-            raise HTTPException(status_code=404, detail="Key not found")
-        else:
-            value = ""
+        value = ""
     masked_value = mask_key_value(value)
     return APIKey(name=name, value=masked_value)
 
@@ -96,6 +92,8 @@ async def set_api_key(api_key: APIKey):
     Adds a new environment variable or updates an existing one.
     Requires authentication.
     """
+    if api_key.name not in [k["name"] for k in MODEL_PROVIDER_KEYS]:
+            raise HTTPException(status_code=404, detail="Key not found")
     if not api_key.value:
         raise HTTPException(status_code=400, detail="Value is required")
     set_env_variable(api_key.name, api_key.value)
@@ -108,6 +106,8 @@ async def delete_api_key(name: str):
     Deletes the specified environment variable.
     Requires authentication.
     """
+    if name not in [k["name"] for k in MODEL_PROVIDER_KEYS]:
+        raise HTTPException(status_code=404, detail="Key not found")
     if get_env_variable(name) is None:
         raise HTTPException(status_code=404, detail="Key not found")
     delete_env_variable(name)

--- a/backend/app/nodes/llm/llm_utils.py
+++ b/backend/app/nodes/llm/llm_utils.py
@@ -281,7 +281,7 @@ class OllamaOptions(BaseModel):
         """Convert to dictionary, excluding None values"""
         return {k: v for k, v in self.model_dump().items() if v is not None}
 
-# @async_retry(wait=wait_random_exponential(min=30, max=120), stop=stop_after_attempt(1))
+@async_retry(wait=wait_random_exponential(min=30, max=120), stop=stop_after_attempt(1))
 async def ollama_with_backoff(
     model: str,
     messages: list[dict[str, str]],

--- a/backend/app/nodes/llm/llm_utils.py
+++ b/backend/app/nodes/llm/llm_utils.py
@@ -281,7 +281,7 @@ class OllamaOptions(BaseModel):
         """Convert to dictionary, excluding None values"""
         return {k: v for k, v in self.model_dump().items() if v is not None}
 
-@async_retry(wait=wait_random_exponential(min=30, max=120), stop=stop_after_attempt(1))
+@async_retry(wait=wait_random_exponential(min=30, max=120), stop=stop_after_attempt(3))
 async def ollama_with_backoff(
     model: str,
     messages: list[dict[str, str]],

--- a/backend/app/nodes/llm/llm_utils.py
+++ b/backend/app/nodes/llm/llm_utils.py
@@ -7,12 +7,16 @@ from typing import Any, Callable, Dict, List, Optional, cast
 
 import numpy as np
 from dotenv import load_dotenv
+import litellm
 from litellm import acompletion
 from pydantic import BaseModel, Field
 from sklearn.metrics.pairwise import cosine_similarity
 from tenacity import AsyncRetrying, stop_after_attempt, wait_random_exponential
 from enum import Enum
+from ollama import AsyncClient
 
+# uncomment for debugging litellm issues
+litellm.set_verbose=True
 load_dotenv()
 
 
@@ -39,6 +43,7 @@ class LLMModels(str, Enum):
     OLLAMA_LLAMA3_3_8B = "ollama/llama3.3"
     OLLAMA_LLAMA3_2_8B = "ollama/llama3.2"
     OLLAMA_LLAMA3_2_1B = "ollama/llama3.2:1b"
+    OLLAMA_LLAMA3_8B = "ollama/llama3"
     OLLAMA_GEMMA_2 = "ollama/gemma2"
     OLLAMA_GEMMA_2_2B = "ollama/gemma2:2b"
     OLLAMA_MISTRAL = "ollama/mistral"
@@ -49,9 +54,6 @@ class LLMModels(str, Enum):
 class ModelInfo(BaseModel):
     model: LLMModels = Field(
         LLMModels.GPT_4O, description="The LLM model to use for completion"
-    )
-    api_base: Optional[str] = Field(
-        None, description="API base URL for model provider (required for Ollama models)"
     )
     max_tokens: Optional[int] = Field(
         ...,
@@ -149,7 +151,7 @@ def async_retry(*dargs, **dkwargs):
     return decorator
 
 
-@async_retry(wait=wait_random_exponential(min=30, max=120), stop=stop_after_attempt(20))
+@async_retry(wait=wait_random_exponential(min=30, max=120), stop=stop_after_attempt(3))
 async def completion_with_backoff(**kwargs) -> str:
     try:
         # Only use api_base if it has a non-empty value
@@ -191,11 +193,18 @@ async def generate_text(
         "messages": messages,
         "temperature": temperature,
     }
-    if json_mode:
+    if json_mode and not model_name.startswith("ollama"):
         kwargs["response_format"] = {"type": "json_object"}
-    if api_base:
-        kwargs["api_base"] = api_base
-    response = await completion_with_backoff(**kwargs)
+        response = await completion_with_backoff(**kwargs)
+    elif json_mode and model_name.startswith("ollama"):
+        options = OllamaOptions(temperature=temperature, max_tokens=max_tokens)
+        response = await ollama_with_backoff(
+            model=model_name,
+            options=options,
+            messages=messages,
+            format="json",
+            api_base=api_base,
+        )
     return cast(str, response)
 
 
@@ -257,3 +266,50 @@ async def find_top_k_similar(
         key = id_extractor(old_doc) if id_extractor else i
         top_k_similar_docs[key] = similar_docs
     return top_k_similar_docs
+
+
+class OllamaOptions(BaseModel):
+    """Options for Ollama API calls"""
+    temperature: float = Field(default=0.7, ge=0.0, le=1.0, description="Controls randomness in responses")
+    max_tokens: Optional[int] = Field(default=None, ge=0, description="Maximum number of tokens to generate")
+    top_p: Optional[float] = Field(default=None, ge=0.0, le=1.0, description="Nucleus sampling threshold")
+    top_k: Optional[int] = Field(default=None, ge=0, description="Number of tokens to consider for top-k sampling")
+    repeat_penalty: Optional[float] = Field(default=None, ge=0.0, description="Penalty for token repetition")
+    stop: Optional[list[str]] = Field(default=None, description="Stop sequences to end generation")
+    
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary, excluding None values"""
+        return {k: v for k, v in self.model_dump().items() if v is not None}
+
+# @async_retry(wait=wait_random_exponential(min=30, max=120), stop=stop_after_attempt(1))
+async def ollama_with_backoff(
+    model: str,
+    messages: list[dict[str, str]],
+    format: Optional[str | dict[str, Any]] = None,
+    options: Optional[OllamaOptions] = None,
+    api_base: Optional[str] = None,
+) -> str:
+    """
+    Make an async Ollama API call with exponential backoff retry logic.
+    
+    Args:
+        model: The name of the Ollama model to use
+        messages: List of message dictionaries with 'role' and 'content'
+        response_model: Optional Pydantic model for response validation
+        options: OllamaOptions instance with model parameters
+        max_retries: Maximum number of retries
+        initial_wait: Initial wait time between retries in seconds
+        max_wait: Maximum wait time between retries in seconds
+    
+    Returns:
+        Either a string response or a validated Pydantic model instance
+    """
+    client = AsyncClient(host=api_base)
+    response = await client.chat(
+        model=model.replace("ollama/", ""),
+        messages=messages,
+        format=format,
+        options=(options or OllamaOptions()).to_dict()
+    )
+    return response.message.content
+    

--- a/backend/app/nodes/llm/single_llm_call.py
+++ b/backend/app/nodes/llm/single_llm_call.py
@@ -1,4 +1,6 @@
 import json
+import os
+from dotenv import load_dotenv
 from typing import Dict, List, Optional
 
 from pydantic import BaseModel, Field
@@ -12,6 +14,7 @@ from ..base import (
 from .llm_utils import LLMModels, ModelInfo, create_messages, generate_text
 from jinja2 import Template
 
+load_dotenv()
 
 class SingleLLMCallNodeConfig(VariableOutputBaseNodeConfig):
     llm_info: ModelInfo = Field(
@@ -77,8 +80,8 @@ class SingleLLMCallNode(VariableOutputBaseNode):
             "temperature": self.config.llm_info.temperature,
             "json_mode": True,
         }
-        if self.config.llm_info.api_base:
-            kwargs["api_base"] = self.config.llm_info.api_base
+        if self.config.llm_info.model.startswith("ollama"):
+            kwargs["api_base"] = os.getenv("OLLAMA_BASE_URL")
         assistant_message = await generate_text(**kwargs)
         assistant_message = json.loads(assistant_message)
         assistant_message = self.output_model.model_validate(assistant_message)

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# First test Ollama connection if URL is provided
+if [ -f "test_ollama.sh" ]; then
+    chmod +x test_ollama.sh
+    ./test_ollama.sh
+fi
+
 set -e 
 mkdir -p /pyspur/app/models/management/alembic/versions/versions
 check_for_changes() {

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -39,3 +39,4 @@ litellm
 alembic
 python-multipart
 httpx==0.27.2
+ollama

--- a/backend/test_ollama.sh
+++ b/backend/test_ollama.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Function for fancy error printing
+print_error() {
+    echo "
+╔════════════════════════════════════════════════════════════════╗
+║                         🚫 ERROR 🚫                            ║
+╠════════════════════════════════════════════════════════════════╣
+║                                                                ║
+║  Cannot connect to Ollama at: $OLLAMA_BASE_URL                ║
+║                                                                ║
+║  Please check:                                                ║
+║    1. Ollama is running                                       ║
+║    2. The OLLAMA_BASE_URL is correct                         ║
+║    3. The network connection is working                       ║
+║                                                                ║
+║  Error details:                                               ║
+║  $1
+║                                                                ║
+╚════════════════════════════════════════════════════════════════╝
+"
+    exit 1
+}
+
+# Check if OLLAMA_BASE_URL is set
+if [ -n "$OLLAMA_BASE_URL" ]; then
+    echo "Testing Ollama connection at: $OLLAMA_BASE_URL"
+    
+    # Try to connect to Ollama
+    response=$(curl -s -w "\n%{http_code}" "$OLLAMA_BASE_URL/api/generate" \
+        -H "Content-Type: application/json" \
+        -d '{
+            "model": "llama2",
+            "prompt": "Why is the sky blue?"
+        }' 2>&1)
+    
+    # Get the HTTP status code
+    http_code=$(echo "$response" | tail -n1)
+    # Get the response body
+    body=$(echo "$response" | sed '$d')
+
+    # Check if curl command was successful
+    if [ $? -ne 0 ]; then
+        print_error "Connection failed: $body"
+    fi
+
+    # Check if we got a successful response
+    if [ "$http_code" -ne 200 ]; then
+        print_error "HTTP Error $http_code: $body"
+    fi
+
+    echo "✅ Successfully connected to Ollama"
+fi 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     volumes:
       - ./backend:/pyspur
       - ./.env:/pyspur/.env
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     restart: always
   frontend:
     build: ./frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   nginx:
     image: nginx:latest
     ports:
-      - "6080:80"
+      - "${NGINX_PORT:-6080}:80"
     volumes:
       - ./nginx/conf.d:/etc/nginx/conf.d
       - ./nginx/.htpasswd:/etc/nginx/.htpasswd
@@ -17,6 +17,7 @@ services:
     command: bash /pyspur/entrypoint.sh
     volumes:
       - ./backend:/pyspur
+      - ./.env:/pyspur/.env
     restart: always
   frontend:
     build: ./frontend
@@ -24,6 +25,9 @@ services:
     volumes:
       - ./frontend:/app
       - /app/node_modules
+    environment:
+      - FRONTEND_PORT=${FRONTEND_PORT:-3000}
+      - FRONTEND_HOST=${FRONTEND_HOST:-0.0.0.0}
     depends_on:
       - backend
     restart: always

--- a/frontend/src/components/modals/SettingsModal.tsx
+++ b/frontend/src/components/modals/SettingsModal.tsx
@@ -20,7 +20,7 @@ import {
   cn,
 } from "@nextui-org/react";
 import { Icon } from "@iconify/react";
-import { listApiKeys, setApiKey, getApiKey, deleteApiKey } from "../../utils/api";
+import { listApiKeys, setApiKey, getApiKey, deleteApiKey } from "@/utils/api";
 import { useTheme } from "next-themes";
 
 // CellWrapper Component
@@ -96,9 +96,9 @@ function APIKeys(props: CardProps) {
 
   const fetchApiKeys = async () => {
     try {
-      const keys = await listApiKeys();
+      const response = await listApiKeys();
       const keyValues = await Promise.all(
-        keys.map(async (key: string) => {
+        response.map(async (key: string) => {
           const value = await getApiKey(key);
           return { name: value.name, value: value.value };
         })

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -255,7 +255,7 @@ export const getAllRuns = async (
 export const listApiKeys = async (): Promise<string[]> => {
   try {
     const response = await axios.get(`${API_BASE_URL}/env-mgmt/`);
-    return response.data.keys;
+    return response.data;
   } catch (error) {
     console.error('Error listing API keys:', error);
     throw error;


### PR DESCRIPTION
## Add support for models hosted by ollama

This PR adds support for connecting self-hosted models using ollama with PySpur. The ollama endpoint has to be specified in the .env file before launching the PySpur service.

Summary of changes:
- use ollama python sdk to generate responses for ollama models. Litellm could not be used as it currently has an unresolved bug with JSON mode https://github.com/BerriAI/litellm/issues/6353
- centralise env management
- minor clean up of key management API and settings modal
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Integrates Ollama models, centralizes environment management, updates key management APIs, and adjusts Docker and frontend for these changes.
> 
>   - **Ollama Integration**:
>     - Added support for Ollama models using `ollama` Python SDK in `llm_utils.py`.
>     - Introduced `OllamaOptions` class for API call options.
>     - Added `ollama_with_backoff()` function for API calls with retry logic.
>   - **Environment Management**:
>     - Centralized environment variable management in `key_management.py`.
>     - Updated `.env.example` with Ollama configuration.
>   - **Key Management API**:
>     - Refactored key management in `key_management.py` to use `MODEL_PROVIDER_KEYS`.
>     - Updated API endpoints to handle Ollama keys.
>   - **Docker and Entrypoint**:
>     - Modified `docker-compose.yml` to include `.env` file and extra hosts.
>     - Added `test_ollama.sh` script to verify Ollama connection in `entrypoint.sh`.
>   - **Frontend Changes**:
>     - Updated `SettingsModal.tsx` and `api.ts` to handle API keys more effectively.
>     - Adjusted API calls to reflect backend changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2FPySpur&utm_source=github&utm_medium=referral)<sup> for 8a5f8867bfc5e2d280a1ae6d827b2cb65c739991. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->