### PR TITLE
Test ollama service with model tags instead of a query

### DIFF
--- a/backend/test_ollama.sh
+++ b/backend/test_ollama.sh
@@ -26,14 +26,10 @@ print_error() {
 if [ -n "$OLLAMA_BASE_URL" ]; then
     echo "Testing Ollama connection at: $OLLAMA_BASE_URL"
     
-    # Try to connect to Ollama
-    response=$(curl -s -w "\n%{http_code}" "$OLLAMA_BASE_URL/api/generate" \
-        -H "Content-Type: application/json" \
-        -d '{
-            "model": "llama2",
-            "prompt": "Why is the sky blue?"
-        }' 2>&1)
-    
+    # Try to fetch the model list from Ollama
+    response=$(curl -s -w "\n%{http_code}" "$OLLAMA_BASE_URL/api/tags" \
+        -H "Content-Type: application/json" 2>&1)
+
     # Get the HTTP status code
     http_code=$(echo "$response" | tail -n1)
     # Get the response body


### PR DESCRIPTION
The original script initiate a chat completion query to ollama every time when the backend entry point starts and `$OLLAMA_BASE_URL` has been set. This is not efficient and has two major drawbacks. First, some users do not use "llama2" because it's relatively weak and obsolete, so ollama has to download the model first and then complete the query, which needs additional disk space for just testing the connection. Second, even with this simple query, ollama has to load the model to memory, initialize the model, then run the query, which cost both time and power. 

My modification is simple. In order to test the connection, we could just query available models from ollama. This query can be instantly finished without generating any chat response, thus expediting the launching speed.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `test_ollama.sh` to test Ollama connection by fetching model list instead of initiating a chat query.
> 
>   - **Behavior**:
>     - Changes connection test in `test_ollama.sh` from initiating a chat completion query to fetching the model list from Ollama.
>     - Avoids downloading and loading the "llama2" model, saving disk space and resources.
>   - **Efficiency**:
>     - Expedites launch speed by eliminating the need to generate a chat response.
>     - Reduces time and power consumption by not loading models into memory.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2FPySpur&utm_source=github&utm_medium=referral)<sup> for 254073b67052d69b04f496e09f90c920bbbb758c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->