### PR TITLE
refactor: simplify DynamicNode component by removing unused state and…

### DIFF
--- a/frontend/src/components/nodes/DynamicNode.tsx
+++ b/frontend/src/components/nodes/DynamicNode.tsx
@@ -11,6 +11,15 @@ import NodeOutputDisplay from './NodeOutputDisplay'
 import NodeOutputModal from './NodeOutputModal'
 import isEqual from 'lodash/isEqual'
 
+const baseNodeStyle = {
+    width: 'auto',
+    minWidth: '300px',
+    maxWidth: '600px',
+    height: 'auto',
+    minHeight: '150px',
+    maxHeight: '800px',
+    transition: 'height 0.3s ease',
+}
 interface SchemaMetadata {
     required?: boolean
     title?: string
@@ -36,9 +45,6 @@ const DynamicNode: React.FC<DynamicNodeProps> = ({
     ...props
 }) => {
     const nodeRef = useRef<HTMLDivElement | null>(null)
-    const [nodeWidth, setNodeWidth] = useState<string>('auto')
-    const [nodeHeight, setNodeHeight] = useState<string>('auto')
-    const [isHoveringOutput, setIsHoveringOutput] = useState(false)
     const [editingField, setEditingField] = useState<string | null>(null)
     const [isCollapsed, setIsCollapsed] = useState<boolean>(false)
     const [isModalOpen, setIsModalOpen] = useState<boolean>(false)
@@ -93,38 +99,6 @@ const DynamicNode: React.FC<DynamicNodeProps> = ({
             })
             .filter(Boolean)
     })
-
-    useEffect(() => {
-        if (!nodeRef.current || !nodeData) return
-
-        const inputLabels = predecessorNodes.map((node) => String(node.data?.title || node?.id || ''))
-        const outputLabels = nodeData?.title ? [String(nodeData.title)] : [String(id)]
-
-        const maxInputLabelLength = inputLabels.reduce((max, label) => Math.max(max, label.length), 0)
-        const maxOutputLabelLength = outputLabels.reduce((max, label) => Math.max(max, label.length), 0)
-        const titleLength = ((nodeData?.title || '').length + 10) * 1.25
-
-        const maxLabelLength = Math.max(maxInputLabelLength + maxOutputLabelLength + 5, titleLength)
-
-        const minNodeWidth = 300
-        const maxNodeWidth = 600
-
-        const finalWidth = Math.min(Math.max(maxLabelLength * 10, minNodeWidth), maxNodeWidth)
-        if (nodeWidth !== `${finalWidth}px`) {
-            setNodeWidth(`${finalWidth}px`)
-        }
-
-        // Calculate height based on number of handles only when there's no run data
-        if (!nodeData.run) {
-            const totalHandles = Math.max(inputLabels.length, outputLabels.length)
-            const handleHeight = 30 // height per handle in pixels
-            const padding = 40 // padding for top and bottom
-            const minNodeHeight = 150 // minimum height
-            const finalHeight = Math.max(minNodeHeight, totalHandles * handleHeight + padding)
-            setNodeHeight(`${finalHeight}px`)
-        }
-    }, [nodeData, cleanedInputMetadata, cleanedOutputMetadata, predecessorNodes, nodeWidth, id])
-
     interface HandleRowProps {
         id: string
         keyName: string
@@ -329,15 +303,6 @@ const DynamicNode: React.FC<DynamicNodeProps> = ({
         )
     }
 
-    const baseNodeStyle = useMemo(
-        () => ({
-            width: isHoveringOutput && nodeData?.run !== undefined ? '600px' : nodeWidth,
-            height: isHoveringOutput && nodeData?.run !== undefined ? '800px' : nodeHeight,
-            transition: 'width 0.3s ease, height 0.3s ease',
-        }),
-        [nodeWidth, nodeHeight, isHoveringOutput, nodeData?.run]
-    )
-
     return (
         <>
             <div className={styles.dynamicNodeWrapper} style={{ zIndex: props.parentId ? 1 : 0 }}>
@@ -361,18 +326,7 @@ const DynamicNode: React.FC<DynamicNodeProps> = ({
                         )}
                         {renderHandles()}
                     </div>
-                    {displayOutput && (
-                        <div
-                            onMouseEnter={() => setIsHoveringOutput(true)}
-                            onMouseLeave={() => setIsHoveringOutput(false)}
-                            style={{
-                                height: 'calc(100% - 60px)', // subtract space for handles
-                                marginTop: '10px'
-                            }}
-                        >
-                            <NodeOutputDisplay key="output-display" output={nodeData.run} />
-                        </div>
-                    )}
+                    {displayOutput && <NodeOutputDisplay key="output-display" output={nodeData.run} />}
                 </BaseNode>
             </div>
             <NodeOutputModal


### PR DESCRIPTION
This pull request includes changes to the `DynamicNode` component in the `frontend/src/components/nodes/DynamicNode.tsx` file to simplify the code and improve the styling of the node.

Code simplification:

* Removed the `useEffect` hook that dynamically calculated the node's width and height based on input and output labels, as well as the `nodeWidth` and `nodeHeight` state variables.
* Removed the `isHoveringOutput` state variable and the corresponding `onMouseEnter` and `onMouseLeave` event handlers for the output display. [[1]](diffhunk://#diff-9319ee5346cc7086a25e5b34b731977f0e408914f038ee01ce8423f1b63c8b61L39-L41) [[2]](diffhunk://#diff-9319ee5346cc7086a25e5b34b731977f0e408914f038ee01ce8423f1b63c8b61L364-R329)
* Removed the `useMemo` hook that dynamically set the `baseNodeStyle` based on the node's state.

Styling improvements:

* Added a new `baseNodeStyle` constant to define the node's width, height, and transition properties.… optimizing styles

- Removed unnecessary state variables for node width and height.
- Introduced a baseNodeStyle object to manage node dimensions and transitions.
- Streamlined rendering logic for NodeOutputDisplay.
- Cleaned up useEffect dependencies and calculations related to node dimensions.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Simplifies `DynamicNode` component by removing unused state/hooks and improving styling with a `baseNodeStyle` constant.
> 
>   - **Code Simplification**:
>     - Removed `useEffect` for dynamic width/height calculation and `nodeWidth`, `nodeHeight` state variables in `DynamicNode`.
>     - Removed `isHoveringOutput` state and related event handlers.
>     - Removed `useMemo` for `baseNodeStyle`.
>   - **Styling Improvements**:
>     - Introduced `baseNodeStyle` constant for node dimensions and transitions.
>     - Simplified rendering logic for `NodeOutputDisplay`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for d7a11c61d8a4d8e76b080d2f51342b3c68c11241. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->