### PR TITLE
Fix json schema types in SchemaEditor and VariableOutputBaseNodeConfig

### DIFF
--- a/backend/app/nodes/base.py
+++ b/backend/app/nodes/base.py
@@ -276,7 +276,7 @@ class FixedOutputBaseNode(BaseNode, ABC):
 
 class VariableOutputBaseNodeConfig(BaseNodeConfig):
     output_schema: Dict[str, str] = Field(
-        default={"output": "str"},
+        default={"output": "string"},
         title="Output schema",
         description="The schema for the output of the node",
     )

--- a/frontend/src/components/nodes/nodeSidebar/SchemaEditor.tsx
+++ b/frontend/src/components/nodes/nodeSidebar/SchemaEditor.tsx
@@ -50,7 +50,7 @@ const SchemaEditor: React.FC<SchemaEditorProps> = ({
 
     const getType = (value: any): string => {
         if (typeof value === 'object' && value !== null) {
-            return value.type || 'str'
+            return value.type || 'string'
         }
         return value
     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix JSON schema type from 'str' to 'string' in `VariableOutputBaseNodeConfig` and `SchemaEditor.tsx`.
> 
>   - **Backend**:
>     - Change default `output_schema` type from `str` to `string` in `VariableOutputBaseNodeConfig` in `base.py`.
>   - **Frontend**:
>     - Update `getType` function in `SchemaEditor.tsx` to return `string` instead of `str` for object types.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for d33c2868a4cff440e0a35175accf5a4c69392065. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->