### PR TITLE
Refactor NodeSidebar component to initialize output JSON schema

### DIFF
--- a/frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx
+++ b/frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx
@@ -418,7 +418,7 @@ const NodeSidebar: React.FC<NodeSidebarProps> = ({ nodeID }) => {
     
     useEffect(() => {
         initializeOutputJsonSchema()
-    }, [currentNodeConfig.output_schema])
+    }, [])
 
     // Update the `renderField` function to include missing cases
     const renderField = (key: string, field: any, value: any, parentPath: string = '', isLast: boolean = false) => {

--- a/frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx
+++ b/frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx
@@ -392,6 +392,34 @@ const NodeSidebar: React.FC<NodeSidebarProps> = ({ nodeID }) => {
         ) as FieldMetadata
     }
 
+    const initializeOutputJsonSchema = () => {
+        if (currentNodeConfig.output_schema && !currentNodeConfig.output_json_schema) {
+            const jsonSchema = generateJsonSchemaFromSchema(currentNodeConfig.output_schema)
+            if (jsonSchema) {
+                const updates = {
+                    output_json_schema: jsonSchema,
+                }
+                setCurrentNodeConfig((prev) => ({
+                    ...prev,
+                    ...updates,
+                }))
+                dispatch(
+                    updateNodeConfigOnly({
+                        id: nodeID,
+                        data: {
+                            ...currentNodeConfig,
+                            ...updates,
+                        },
+                    })
+                )
+            }
+        }
+    }
+    
+    useEffect(() => {
+        initializeOutputJsonSchema()
+    }, [currentNodeConfig.output_schema])
+
     // Update the `renderField` function to include missing cases
     const renderField = (key: string, field: any, value: any, parentPath: string = '', isLast: boolean = false) => {
         const fullPath = `${parentPath ? `${parentPath}.` : ''}${key}`

--- a/frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx
+++ b/frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx
@@ -393,31 +393,31 @@ const NodeSidebar: React.FC<NodeSidebarProps> = ({ nodeID }) => {
     }
 
     const initializeOutputJsonSchema = () => {
-        if (currentNodeConfig.output_schema && !currentNodeConfig.output_json_schema) {
-            const jsonSchema = generateJsonSchemaFromSchema(currentNodeConfig.output_schema)
-            if (jsonSchema) {
-                const updates = {
-                    output_json_schema: jsonSchema,
-                }
-                setCurrentNodeConfig((prev) => ({
-                    ...prev,
-                    ...updates,
-                }))
-                dispatch(
-                    updateNodeConfigOnly({
-                        id: nodeID,
-                        data: {
-                            ...currentNodeConfig,
-                            ...updates,
-                        },
-                    })
-                )
+        const jsonSchema = generateJsonSchemaFromSchema(currentNodeConfig.output_schema)
+        if (jsonSchema) {
+            const updates = {
+                output_json_schema: jsonSchema,
             }
+            setCurrentNodeConfig((prev) => ({
+                ...prev,
+                ...updates,
+            }))
+            dispatch(
+                updateNodeConfigOnly({
+                    id: nodeID,
+                    data: {
+                        ...currentNodeConfig,
+                        ...updates,
+                    },
+                })
+            )
         }
     }
-    
+
     useEffect(() => {
-        initializeOutputJsonSchema()
+        if (currentNodeConfig.output_schema && !currentNodeConfig.output_json_schema) {
+            initializeOutputJsonSchema()
+        }
     }, [])
 
     // Update the `renderField` function to include missing cases
@@ -949,8 +949,10 @@ const NodeSidebar: React.FC<NodeSidebarProps> = ({ nodeID }) => {
     }
 
     return (
-        <Card className="fixed top-16 bottom-4 right-4 p-4 rounded-xl border border-solid border-default-200 overflow-auto"
-            style={{ width: `${width}px` }}>
+        <Card
+            className="fixed top-16 bottom-4 right-4 p-4 rounded-xl border border-solid border-default-200 overflow-auto"
+            style={{ width: `${width}px` }}
+        >
             {showTitleError && (
                 <Alert
                     key={`alert-${nodeID}`}
@@ -976,7 +978,7 @@ const NodeSidebar: React.FC<NodeSidebarProps> = ({ nodeID }) => {
                         backgroundColor: isResizing ? 'var(--nextui-colors-primary)' : undefined,
                         opacity: isResizing ? 1 : 0,
                     }}
-                    onMouseEnter={(e) => e.currentTarget.style.opacity = '1'}
+                    onMouseEnter={(e) => (e.currentTarget.style.opacity = '1')}
                     onMouseLeave={(e) => !isResizing && (e.currentTarget.style.opacity = '0')}
                 />
 


### PR DESCRIPTION
The purpose of this change is to ensure that the output JSON schema is always present when the output schema is defined, improving the consistency and reliability of the NodeSidebar component.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `initializeOutputJsonSchema()` in `NodeSidebar.tsx` to ensure `output_json_schema` is initialized when `output_schema` is defined.
> 
>   - **Behavior**:
>     - Adds `initializeOutputJsonSchema()` in `NodeSidebar.tsx` to generate and set `output_json_schema` if `output_schema` is defined but `output_json_schema` is not.
>     - Uses `useEffect` to call `initializeOutputJsonSchema()` on component mount if conditions are met.
>   - **Misc**:
>     - Minor formatting changes in `NodeSidebar.tsx` for better readability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for 0a0e181f6f42a9901341dc447bec85c61a5f2801. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->