### PR TITLE
bring back router node title in prefix

### DIFF
--- a/backend/app/nodes/llm/single_llm_call.py
+++ b/backend/app/nodes/llm/single_llm_call.py
@@ -111,7 +111,11 @@ class SingleLLMCallNode(VariableOutputBaseNode):
             url_vars = {}
             if "file" in self.config.url_variables:
                 # Split the input variable reference (e.g. "input_node.video_url")
-                node_id, var_name = self.config.url_variables["file"].split(".")
+                parts = self.config.url_variables["file"].split(".")
+                if len(parts) == 2:
+                    node_id, var_name = parts
+                else:
+                    node_id, var_name = parts[0], parts[-1]
                 # Get the value from the input using the node_id
                 if node_id in raw_input_dict and var_name in raw_input_dict[node_id]:
                     # Always use image_url format regardless of file type

--- a/backend/app/nodes/logic/router.py
+++ b/backend/app/nodes/logic/router.py
@@ -124,7 +124,7 @@ class RouterNode(BaseNode):
         """
         output_model = create_model(  # type: ignore
             f"{self.name}",
-            **{field_name: (field_type, ...) for field_name, field_type in input.__fields__.items()},  # type: ignore
+            **{field_name: (field_type, ...) for field_name, field_type in input.model_fields.items()},  # type: ignore
             __base__=RouterNodeOutput,
         )
         # Create fields for each route with Optional[input type]
@@ -143,7 +143,7 @@ class RouterNode(BaseNode):
 
         for route_name, route in self.config.route_map.items():
             if self._evaluate_route_conditions(input, route):
-                output[route_name] = output_model(**input.model_dump())
+                output[route_name] = output_model(**input.model_dump())  # type: ignore
 
         return self.output_model(**output)  # type: ignore
 
@@ -189,4 +189,7 @@ if __name__ == "__main__":
 
     input_data = TestInput(name="Alice", age=20, is_student=True, grade="B")
     output = asyncio.run(node(input_data))
-    print(output)
+    import json
+
+    print(json.dumps(output.model_json_schema(), indent=2))
+    print(json.dumps(output.model_dump(), indent=2))

--- a/frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx
+++ b/frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx
@@ -183,9 +183,6 @@ const NodeSidebar: React.FC<NodeSidebarProps> = ({ nodeID }) => {
             const config = allNodeConfigs[node.id]
             if (config?.output_schema) {
                 const nodeTitle = config.title || node.id
-                if (node.type === 'RouterNode') {
-                    return [...acc, ...Object.keys(config.output_schema).map((key) => `${key}`)]
-                }
                 return [...acc, ...Object.keys(config.output_schema).map((key) => `${nodeTitle}.${key}`)]
             }
             return acc


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance URL variable handling in LLM nodes, update router node output model creation, and include node titles in NodeSidebar output schema keys.
> 
>   - **Backend**:
>     - `single_llm_call.py`: Adjust URL variable handling to support cases with more than two parts by using the first and last parts as `node_id` and `var_name`.
>     - `router.py`: Change `input.__fields__` to `input.model_fields` for output model creation.
>     - Add JSON schema printing in `router.py` test case.
>   - **Frontend**:
>     - `NodeSidebar.tsx`: Remove special handling for `RouterNode` in `collectIncomingSchema`, ensuring node titles are included in output schema keys.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for 8cfd7c541524cc5fad8ca46890505cf2dab98357. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->