### PR TITLE
Fix/deploy modal

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -119,14 +119,6 @@ const Header: React.FC<HeaderProps> = ({ activePage, associatedWorkflowId }) => 
         setIsDeployModalOpen(true)
     }
 
-    const getApiEndpoint = (): string => {
-        if (typeof window === 'undefined') {
-            return ''
-        }
-        const baseUrl = window.location.origin
-        return `${baseUrl}/api/wf/${workflowId}/start_run/?run_type=non_blocking`
-    }
-
     useEffect(() => {
         if (isHistoryOpen) {
             updateRunStatuses()
@@ -359,11 +351,7 @@ const Header: React.FC<HeaderProps> = ({ activePage, associatedWorkflowId }) => 
                     setIsDebugModalOpen(false)
                 }}
             />
-            <DeployModal
-                isOpen={isDeployModalOpen}
-                onOpenChange={setIsDeployModalOpen}
-                getApiEndpoint={getApiEndpoint}
-            />
+            <DeployModal isOpen={isDeployModalOpen} onOpenChange={setIsDeployModalOpen} workflowId={workflowId} />
         </>
     )
 }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -351,7 +351,12 @@ const Header: React.FC<HeaderProps> = ({ activePage, associatedWorkflowId }) => 
                     setIsDebugModalOpen(false)
                 }}
             />
-            <DeployModal isOpen={isDeployModalOpen} onOpenChange={setIsDeployModalOpen} workflowId={workflowId} />
+            <DeployModal
+                isOpen={isDeployModalOpen}
+                onOpenChange={setIsDeployModalOpen}
+                workflowId={workflowId}
+                testInput={testInputs.find((row) => row.id === selectedRow) ?? testInputs[0]}
+            />
         </>
     )
 }

--- a/frontend/src/components/modals/DeployModal.tsx
+++ b/frontend/src/components/modals/DeployModal.tsx
@@ -51,15 +51,17 @@ const DeployModal: React.FC<DeployModalProps> = ({ isOpen, onOpenChange, workflo
 
     // Create example request body with the actual input variables
     const exampleRequestBody = {
-        initial_inputs: Object.keys(workflowInputVariables).reduce<Record<string, any>>((acc, key) => {
-            acc[key] =
-                workflowInputVariables[key].type === 'number'
-                    ? 0
-                    : workflowInputVariables[key].type === 'boolean'
-                      ? false
-                      : 'example_value'
-            return acc
-        }, {}),
+        initial_inputs: {
+            [inputNode.data.title]: Object.keys(workflowInputVariables).reduce<Record<string, any>>((acc, key) => {
+                acc[key] =
+                    workflowInputVariables[key].type === 'number'
+                        ? 0
+                        : workflowInputVariables[key].type === 'boolean'
+                          ? false
+                          : 'example_value'
+                return acc
+            }, {}),
+        },
     }
 
     const getCodeExample = (language: SupportedLanguages): string => {

--- a/frontend/src/components/modals/DeployModal.tsx
+++ b/frontend/src/components/modals/DeployModal.tsx
@@ -170,6 +170,87 @@ int main() {
         return examples[language]
     }
 
+    const getStatusEndpoint = (): string => {
+        if (typeof window === 'undefined') {
+            return ''
+        }
+        const baseUrl = window.location.origin
+        return `${baseUrl}/api/runs/{run_id}/status/`
+    }
+
+    const getStatusCheckExample = (language: SupportedLanguages): string => {
+        const endpoint = getStatusEndpoint()
+
+        const examples: Record<SupportedLanguages, string> = {
+            shell: `curl ${endpoint.replace('{run_id}', 'YOUR_RUN_ID')}`,
+
+            python: `import requests
+
+url = '${endpoint.replace('{run_id}', 'YOUR_RUN_ID')}'
+
+response = requests.get(url)
+print(response.json())`,
+
+            javascript: `fetch('${endpoint.replace('{run_id}', 'YOUR_RUN_ID')}')
+  .then(response => response.json())
+  .then(data => console.log(data))
+  .catch(error => console.error('Error:', error));`,
+
+            typescript: `async function checkRunStatus(runId: string) {
+  const response = await fetch('${endpoint.replace('{run_id}', '')}' + runId);
+  const data = await response.json();
+  console.log(data);
+}`,
+
+            rust: `use reqwest;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = reqwest::Client::new();
+    let response = client
+        .get("${endpoint.replace('{run_id}', 'YOUR_RUN_ID')}")
+        .send()
+        .await?;
+
+    println!("Response: {}", response.text().await?);
+    Ok(())
+}`,
+
+            java: `import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.URI;
+
+public class StatusCheck {
+    public static void main(String[] args) throws Exception {
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create("${endpoint.replace('{run_id}', 'YOUR_RUN_ID')}"))
+            .GET()
+            .build();
+
+        HttpResponse<String> response = client.send(request,
+            HttpResponse.BodyHandlers.ofString());
+
+        System.out.println(response.body());
+    }
+}`,
+
+            cpp: `#include <cpr/cpr.h>
+#include <iostream>
+
+int main() {
+    cpr::Response r = cpr::Get(
+        cpr::Url{"${endpoint.replace('{run_id}', 'YOUR_RUN_ID')}"});
+
+    std::cout << "Response: " << r.text << std::endl;
+    return 0;
+}`,
+        }
+
+        return examples[language]
+    }
+
     return (
         <Modal isOpen={isOpen} onOpenChange={onOpenChange} size="2xl">
             <ModalContent>
@@ -247,6 +328,38 @@ int main() {
                             </Tooltip>
                         </div>
                     </div>
+
+                    {apiCallType === 'non-blocking' && (
+                        <div className="mt-4">
+                            <p className="mb-2">Check run status:</p>
+                            <div className="flex items-center gap-2 w-full">
+                                <SyntaxHighlighter
+                                    language={selectedLanguage}
+                                    style={oneDark}
+                                    customStyle={{
+                                        margin: 0,
+                                        borderRadius: '8px',
+                                        padding: '12px',
+                                        flex: 1,
+                                    }}
+                                >
+                                    {getStatusCheckExample(selectedLanguage)}
+                                </SyntaxHighlighter>
+                                <Tooltip content="Copy to clipboard">
+                                    <Button
+                                        isIconOnly
+                                        variant="light"
+                                        size="sm"
+                                        onClick={() => {
+                                            navigator.clipboard.writeText(getStatusCheckExample(selectedLanguage))
+                                        }}
+                                    >
+                                        <Icon icon="solar:copy-linear" width={20} />
+                                    </Button>
+                                </Tooltip>
+                            </div>
+                        </div>
+                    )}
                 </ModalBody>
                 <ModalFooter>
                     <Button color="primary" onPress={() => onOpenChange(false)}>

--- a/frontend/src/components/modals/DeployModal.tsx
+++ b/frontend/src/components/modals/DeployModal.tsx
@@ -147,7 +147,7 @@ int main() {
                     <div>API Endpoint Information</div>
                 </ModalHeader>
 
-                <ModalBody>
+                <ModalBody className="max-h-[60vh] overflow-y-auto">
                     <p>Use this endpoint to run your workflow in a non-blocking way:</p>
                     <div className="flex items-center gap-2 w-full">
                         <SyntaxHighlighter


### PR DESCRIPTION
This pull request introduces significant changes to the `DeployModal` component, including refactoring the API endpoint logic and enhancing the UI for better user interaction. The most important changes include moving the `getApiEndpoint` function to `DeployModal`, adding support for blocking and non-blocking API calls, and updating the UI to allow users to select the API call type and language for code examples.

Refactoring and functionality improvements:

* [`frontend/src/components/Header.tsx`](diffhunk://#diff-c510609aa826d49ad460d88069bb38a03f4369437f399594f14aa6019327c9cdL122-L129): Removed the `getApiEndpoint` function from `Header` and updated the `DeployModal` component to accept `workflowId` and `testInput` as props. [[1]](diffhunk://#diff-c510609aa826d49ad460d88069bb38a03f4369437f399594f14aa6019327c9cdL122-L129) [[2]](diffhunk://#diff-c510609aa826d49ad460d88069bb38a03f4369437f399594f14aa6019327c9cdL365-R358)
* [`frontend/src/components/modals/DeployModal.tsx`](diffhunk://#diff-03e36b3f650c315760a18e9468f3519bb92e8138d3fe28f705b32b7f38d7e121R13-R89): Moved the `getApiEndpoint` function to `DeployModal` and added a new state `apiCallType` to handle blocking and non-blocking API calls. [[1]](diffhunk://#diff-03e36b3f650c315760a18e9468f3519bb92e8138d3fe28f705b32b7f38d7e121R13-R89) [[2]](diffhunk://#diff-03e36b3f650c315760a18e9468f3519bb92e8138d3fe28f705b32b7f38d7e121L74-R101)

UI enhancements:

* [`frontend/src/components/modals/DeployModal.tsx`](diffhunk://#diff-03e36b3f650c315760a18e9468f3519bb92e8138d3fe28f705b32b7f38d7e121R170-R306): Updated the modal body to include dropdowns for selecting the API call type and language for code examples. [[1]](diffhunk://#diff-03e36b3f650c315760a18e9468f3519bb92e8138d3fe28f705b32b7f38d7e121R170-R306) [[2]](diffhunk://#diff-03e36b3f650c315760a18e9468f3519bb92e8138d3fe28f705b32b7f38d7e121L190-R334)
* [`frontend/src/components/modals/DeployModal.tsx`](diffhunk://#diff-03e36b3f650c315760a18e9468f3519bb92e8138d3fe28f705b32b7f38d7e121R170-R306): Added functions `getStatusEndpoint` and `getStatusCheckExample` to provide examples for checking the status of a run. [[1]](diffhunk://#diff-03e36b3f650c315760a18e9468f3519bb92e8138d3fe28f705b32b7f38d7e121R170-R306) [[2]](diffhunk://#diff-03e36b3f650c315760a18e9468f3519bb92e8138d3fe28f705b32b7f38d7e121L236-R362)

These changes improve the flexibility and usability of the `DeployModal` component, allowing users to easily switch between different API call types and view code examples in various programming languages.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `DeployModal` to support blocking/non-blocking API calls and enhance UI for selecting API call types and languages.
> 
>   - **Refactoring**:
>     - Move `getApiEndpoint` from `Header` to `DeployModal`.
>     - Update `DeployModal` to accept `workflowId` and `testInput` as props.
>   - **Functionality**:
>     - Add `apiCallType` state in `DeployModal` for blocking and non-blocking API calls.
>     - Add `getStatusEndpoint` and `getStatusCheckExample` functions in `DeployModal`.
>   - **UI Enhancements**:
>     - Add dropdowns in `DeployModal` for selecting API call type and language for code examples.
>     - Update code examples in `DeployModal` to reflect selected API call type and language.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for 8b5e3fbe91e157d4491caaa402cad14df8c19039. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->