### PR TITLE
Feat/for loop fe

### DIFF
--- a/backend/app/execution/task_recorder.py
+++ b/backend/app/execution/task_recorder.py
@@ -56,7 +56,12 @@ class TaskRecorder:
             task.subworkflow = subworkflow.model_dump()
         if subworkflow_output:
             task.subworkflow_output = {
-                k: v.model_dump() for k, v in subworkflow_output.items()
+                k: (
+                    [x.model_dump() if isinstance(x, BaseModel) else x for x in v]
+                    if isinstance(v, list)
+                    else v.model_dump()
+                )
+                for k, v in subworkflow_output.items()
             }
         self.db.add(task)
         self.db.commit()

--- a/backend/app/nodes/base.py
+++ b/backend/app/nodes/base.py
@@ -97,9 +97,17 @@ class BaseNode(ABC):
         """
         Dynamically creates an output model based on the node's output schema.
         """
+        field_type_to_python_type = {
+            "string": str,
+            "integer": int,
+            "number": float,
+            "boolean": bool,
+            "list": list,
+            "dict": dict,
+        }
         return create_model(
             f"{self.name}",
-            **{field_name: (field_type, ...) for field_name, field_type in output_schema.items()},  # type: ignore
+            **{field_name: (field_type_to_python_type[field_type], ...) for field_name, field_type in output_schema.items()},  # type: ignore
             __base__=BaseNodeOutput,
         )
 

--- a/backend/app/nodes/loops/base_loop_subworkflow_node.py
+++ b/backend/app/nodes/loops/base_loop_subworkflow_node.py
@@ -101,7 +101,7 @@ class BaseLoopSubworkflowNode(BaseSubworkflowNode):
             current_input.update(iteration_output)
             self.iteration += 1
 
-        self.subworkflow_outputs = self.loop_outputs
+        self.subworkflow_output = self.loop_outputs
 
         # Return final state as BaseModel
         return self.output_model.model_validate(current_input)  # type: ignore

--- a/backend/app/nodes/loops/for_loop_node.py
+++ b/backend/app/nodes/loops/for_loop_node.py
@@ -113,6 +113,6 @@ return {
         input_data = TestInput()
         output = await node(input_data)
         pprint(output)
-        pprint(node.subworkflow_outputs)
+        pprint(node.subworkflow_output)
 
     asyncio.run(main())

--- a/backend/app/nodes/node_types.py
+++ b/backend/app/nodes/node_types.py
@@ -55,13 +55,13 @@ SUPPORTED_NODE_TYPES = {
         },
     ],
     "Logic": LOGIC,
-    # "Loop": [
-    #     {
-    #         "node_type_name": "ForLoopNode",
-    #         "module": ".nodes.loops.for_loop_node",
-    #         "class_name": "ForLoopNode",
-    #     },
-    # ],
+    "Experimental": [
+        {
+            "node_type_name": "ForLoopNode",
+            "module": ".nodes.loops.for_loop_node",
+            "class_name": "ForLoopNode",
+        },
+    ],
     "Integrations": [
         {
             "node_type_name": "SlackNotifyNode",

--- a/frontend/src/components/canvas/RunViewFlowCanvas.tsx
+++ b/frontend/src/components/canvas/RunViewFlowCanvas.tsx
@@ -65,7 +65,9 @@ const RunViewFlowCanvasContent: React.FC<RunViewFlowCanvasProps> = ({ workflowDa
     useEffect(() => {
         if (workflowData) {
             if (workflowData.definition.nodes) {
-                const inputNode = workflowData.definition.nodes.filter((node) => node.node_type === 'InputNode')
+                const inputNode = workflowData.definition.nodes.filter(
+                    (node) => node.node_type === 'InputNode' && node.parent_id === null
+                )
                 if (inputNode.length > 0) {
                     const inputSchema = inputNode[0].config.input_schema
                     if (inputSchema) {

--- a/frontend/src/components/nodes/InputNode.tsx
+++ b/frontend/src/components/nodes/InputNode.tsx
@@ -314,6 +314,8 @@ const InputNode: React.FC<InputNodeProps> = ({ id, data, readOnly = false, ...pr
     const baseNodeStyles = useMemo(
         () => ({
             width: nodeWidth,
+            maxHeight: '800px',
+            overflow: 'auto',
         }),
         [nodeWidth]
     )

--- a/frontend/src/components/nodes/NodeOutputDisplay.tsx
+++ b/frontend/src/components/nodes/NodeOutputDisplay.tsx
@@ -49,19 +49,19 @@ const NodeOutputDisplay: React.FC<NodeOutputDisplayProps> = ({ output }) => {
             'class ',
             // Variable declarations
             'const ',
-            'let ',
+            // 'let ',
             'var ',
             'int ',
             'float ',
             // Imports
-            'import ',
-            'from ',
+            // 'import ',
+            // 'from ',
             '#include',
             // Control structures
-            'if ',
-            'for ',
-            'while ',
-            'return ',
+            // 'if ',
+            // 'for ',
+            // 'while ',
+            // 'return ',
         ]
         return value.includes('\n') && codeIndicators.some((indicator) => value.includes(indicator))
     }

--- a/frontend/src/components/nodes/loops/groupNodeUtils.ts
+++ b/frontend/src/components/nodes/loops/groupNodeUtils.ts
@@ -190,7 +190,7 @@ export const createDynamicGroupNodeWithChildren = (
         const inputNodeAndConfig = createNode(
             nodeTypes,
             'InputNode',
-            `${id}-input`,
+            `${id}_input`,
             {
                 x: position.x + 50,
                 y: position.y + 300, // position.y + (height/2)
@@ -202,7 +202,7 @@ export const createDynamicGroupNodeWithChildren = (
         const outputNodeAndConfig = createNode(
             nodeTypes,
             'OutputNode',
-            `${id}-output`,
+            `${id}_output`,
             {
                 x: position.x + 950, // position.x + width - 250
                 y: position.y + 300, // position.y + (height/2)

--- a/frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx
+++ b/frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx
@@ -724,6 +724,9 @@ const NodeSidebar: React.FC<NodeSidebarProps> = ({ nodeID }) => {
         if (key === 'input_map') {
             return renderInputMapField(key, value, incomingSchema, handleInputChange)
         }
+        if (key === 'output_map') {
+            return renderOutputMapField(key, value, incomingSchema, handleInputChange)
+        }
 
         // Handle other types (string, number, boolean, object)
         switch (typeof field) {
@@ -1029,6 +1032,38 @@ const NodeSidebar: React.FC<NodeSidebarProps> = ({ nodeID }) => {
                     onChange={(newValue) => handleInputChange(key, newValue)}
                     options={jsonOptions}
                     schemaType="input_map"
+                    nodeId={nodeID}
+                    availableFields={incomingSchema}
+                />
+            </div>
+        )
+    }
+
+    const renderOutputMapField = (
+        key: string,
+        value: any,
+        incomingSchema: string[],
+        handleInputChange: (key: string, value: any) => void
+    ) => {
+        return (
+            <div key={key} className="my-2">
+                <div className="flex items-center gap-2 mb-2">
+                    <h3 className="font-semibold">Output Mapping</h3>
+                    <Tooltip
+                        content="Map fields from this node's output schema to the incoming variables of this node"
+                        placement="left-start"
+                        showArrow={true}
+                        className="max-w-xs"
+                    >
+                        <Icon icon="solar:question-circle-linear" className="text-default-400 cursor-help" width={20} />
+                    </Tooltip>
+                </div>
+                <SchemaEditor
+                    key={`output-map-editor-${nodeID}`}
+                    jsonValue={value || {}}
+                    onChange={(newValue) => handleInputChange(key, newValue)}
+                    options={jsonOptions}
+                    schemaType="output_map"
                     nodeId={nodeID}
                     availableFields={incomingSchema}
                 />

--- a/frontend/src/components/nodes/nodeSidebar/SchemaEditor.tsx
+++ b/frontend/src/components/nodes/nodeSidebar/SchemaEditor.tsx
@@ -9,7 +9,7 @@ interface SchemaEditorProps {
     onChange: (value: Record<string, string>) => void
     options?: string[]
     disabled?: boolean
-    schemaType?: 'input_schema' | 'output_schema' | 'input_map'
+    schemaType?: 'input_schema' | 'output_schema' | 'input_map' | 'output_map'
     nodeId: string
     availableFields?: string[]
 }
@@ -71,7 +71,7 @@ const SchemaEditor: React.FC<SchemaEditorProps> = ({
         delete updatedJson[oldKey]
 
         onChange(updatedJson)
-        if (newKey && oldKey && schemaType !== 'input_map') {
+        if (newKey && oldKey && schemaType !== 'input_map' && schemaType !== 'output_map') {
             dispatch(
                 updateEdgesOnHandleRename({
                     nodeId,
@@ -84,7 +84,7 @@ const SchemaEditor: React.FC<SchemaEditorProps> = ({
         setEditingField(null)
     }
 
-    const label = schemaType === 'input_map' ? 'Field' : 'Type'
+    const label = schemaType === 'input_map' || schemaType === 'output_map' ? 'Field' : 'Type'
 
     return (
         <div className="json-editor">

--- a/frontend/src/hooks/useWorkflowExecution.ts
+++ b/frontend/src/hooks/useWorkflowExecution.ts
@@ -61,6 +61,27 @@ export const useWorkflowExecution = ({ onAlert }: UseWorkflowExecutionProps) => 
                         }
                         const output_values = task.outputs || {}
                         const nodeTaskStatus = task.status
+
+                        // Handle subworkflow outputs if they exist
+                        if (task.subworkflow_output) {
+                            Object.entries(task.subworkflow_output).forEach(([subNodeId, outputs]) => {
+                                const subNode = nodes.find(
+                                    (node) => node.id === subNodeId || node.data.title === subNodeId
+                                )
+                                if (subNode) {
+                                    dispatch(
+                                        updateNodeDataOnly({
+                                            id: subNode.id,
+                                            data: {
+                                                run: outputs,
+                                                taskStatus: 'COMPLETED', // Assuming subworkflow outputs are from completed tasks
+                                            },
+                                        })
+                                    )
+                                }
+                            })
+                        }
+
                         if (node) {
                             dispatch(
                                 updateNodeDataOnly({

--- a/frontend/src/utils/nodeLayoutUtils.ts
+++ b/frontend/src/utils/nodeLayoutUtils.ts
@@ -13,7 +13,7 @@ export const getLayoutedNodes = (nodes: FlowWorkflowNode[], edges: FlowWorkflowE
     dagreGraph.setDefaultEdgeLabel(() => ({}))
 
     nodes.forEach((node) => {
-        if (node.measured) {
+        if (node.measured && node.parentId === null) {
             dagreGraph.setNode(node.id, {
                 width: node.measured.width,
                 height: node.measured.height,

--- a/frontend/src/utils/subworkflowUtils.ts
+++ b/frontend/src/utils/subworkflowUtils.ts
@@ -23,6 +23,16 @@ export function rolloutWorkflowDefinition({ workflowDefinition, tasks }: Rollout
 
         if (!task.subworkflow) return
 
+        // Find the node type
+        const nodeType = rolledOutDefinition.nodes.find((node) => node.id === task.node_id).node_type
+        if (nodeType === 'ForLoopNode') {
+            // just pull the subworkflow outputs into the parent node
+            if (task.subworkflow_output) {
+                outputs = { ...outputs, ...task.subworkflow_output }
+            }
+            return
+        }
+
         const nodeToReplace = rolledOutDefinition.nodes.find((node) => node.id === task.node_id)
         if (!nodeToReplace) return
 


### PR DESCRIPTION
## For Loop - Part 3

Releasing for loop node in "Experimental" nodes.

---

This pull request includes several changes to the backend and frontend of the application, focusing on handling subworkflows, improving type safety, and enhancing the user interface. The most important changes include updating the task recorder to handle subworkflow outputs properly, processing subworkflows in the workflow executor, and improving the user interface for node output mapping.

Backend changes:

* [`backend/app/execution/task_recorder.py`](diffhunk://#diff-e9f5d266ceb5d441ce834b93e5da636bdda1d9450e910cdeed5783c52a94bd8cL59-R64): Updated the `update_task` method to handle subworkflow outputs that may contain lists of BaseModel instances.
* [`backend/app/execution/workflow_executor.py`](diffhunk://#diff-8dd10b9c91f03781032cea965cb1788a2d49b9fb01a800ac09a2a7b6654ecd68L30-R31): Added a `_process_subworkflows` method to handle the initialization of subworkflows before setting other attributes. [[1]](diffhunk://#diff-8dd10b9c91f03781032cea965cb1788a2d49b9fb01a800ac09a2a7b6654ecd68L30-R31) [[2]](diffhunk://#diff-8dd10b9c91f03781032cea965cb1788a2d49b9fb01a800ac09a2a7b6654ecd68L42-R107)
* [`backend/app/nodes/base.py`](diffhunk://#diff-42496992867651ac2a1d3ed4af031ad36e0b524c410b9a99aef11d078be0a4a5R100-R110): Introduced a mapping from field types to Python types in the `create_output_model_class` function to ensure correct type handling.

Frontend changes:

* [`frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx`](diffhunk://#diff-bfbb4b8da1bcfb622620d5706176334f1a893d4dc5442ef0144bbf26e6162a26R727-R729): Added support for rendering output map fields in the node sidebar. [[1]](diffhunk://#diff-bfbb4b8da1bcfb622620d5706176334f1a893d4dc5442ef0144bbf26e6162a26R727-R729) [[2]](diffhunk://#diff-bfbb4b8da1bcfb622620d5706176334f1a893d4dc5442ef0144bbf26e6162a26R1042-R1073)
* [`frontend/src/hooks/useWorkflowExecution.ts`](diffhunk://#diff-33742275b345d738acf29b65b38e2766a241fa90a9024f70eb30c77448876450R64-R84): Enhanced the workflow execution hook to handle subworkflow outputs and update the node data accordingly.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces for loop nodes with backend subworkflow processing and frontend UI enhancements for output mapping.
> 
>   - **Backend**:
>     - `task_recorder.py`: Updated `update_task` to handle subworkflow outputs with lists of `BaseModel` instances.
>     - `workflow_executor.py`: Added `_process_subworkflows` to initialize subworkflows and updated workflow execution logic.
>     - `base.py`: Introduced type mapping in `create_output_model_class` for correct type handling.
>   - **Frontend**:
>     - `NodeSidebar.tsx`: Added rendering for output map fields and updated schema editor for output mapping.
>     - `useWorkflowExecution.ts`: Enhanced to handle subworkflow outputs and update node data.
>     - `RunViewFlowCanvas.tsx`: Filtered input nodes to exclude those with parents.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for 8ae7d21f61d832698bb8195271389cff6df40a76. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->