### PR TITLE
feat: support non-JSON models

### DIFF
--- a/frontend/src/components/nodes/InputNode.tsx
+++ b/frontend/src/components/nodes/InputNode.tsx
@@ -29,7 +29,6 @@ const InputNode: React.FC<InputNodeProps> = ({ id, data, readOnly = false, ...pr
     const [newFieldValue, setNewFieldValue] = useState<string>('')
     const [isCollapsed, setIsCollapsed] = useState<boolean>(false)
     const [showKeyError, setShowKeyError] = useState<boolean>(false)
-    const [showOutput, setShowOutput] = useState(false)
     const incomingEdges = useSelector(
         (state: RootState) => state.flow.edges.filter((edge) => edge.target === id),
         isEqual
@@ -80,7 +79,7 @@ const InputNode: React.FC<InputNodeProps> = ({ id, data, readOnly = false, ...pr
         dispatch(
             setWorkflowInputVariable({
                 key: newKey,
-                value: 'str',
+                value: 'string',
             })
         )
         setNewFieldValue('')

--- a/frontend/src/store/nodeTypesSlice.ts
+++ b/frontend/src/store/nodeTypesSlice.ts
@@ -73,6 +73,7 @@ export interface ModelConstraints {
     max_tokens: number
     min_temperature: number
     max_temperature: number
+    supports_JSON_output: boolean
 }
 
 export interface ModelConstraintsMap {


### PR DESCRIPTION
Using DeepSeek-Reasoner
<img width="938" alt="Screenshot 2025-01-22 at 13 26 54" src="https://github.com/user-attachments/assets/e188d167-5caf-40d0-991a-aede1f7f9d24" />

When the user chooses a model that doesn't supprt JSON, they see this:
<img width="385" alt="Screenshot 2025-01-22 at 13 28 19" src="https://github.com/user-attachments/assets/450a0fa7-663a-452c-b3b9-892297c8edd2" />


This pull request includes changes to the backend and frontend to support models with that do not support JSON output schemas. We do this by hard-coding a `{"output": ...}` output json schema for them.
The main updates involve adding a new constraint for JSON output support and adjusting the logic accordingly in both the backend and frontend components.

### Backend changes:
* Added `supports_JSON_output` attribute to `ModelConstraints` in `backend/app/nodes/llm/_utils.py`.
* Updated `LLMModels` enum values to include detailed model identifiers.
* Modified `get_model_info` method to include `supports_JSON_output` for specific models. [[1]](diffhunk://#diff-5d3705160b8f044a9ab21236b674e1a3bd295b8062beb79e91b7db34646a9cacL245-R252) [[2]](diffhunk://#diff-5d3705160b8f044a9ab21236b674e1a3bd295b8062beb79e91b7db34646a9cacR261-R266)
* Enhanced `generate_text` function to handle models with and without JSON output support, including wrapping responses for models that do not support JSON output. [[1]](diffhunk://#diff-5d3705160b8f044a9ab21236b674e1a3bd295b8062beb79e91b7db34646a9cacR501-R507) [[2]](diffhunk://#diff-5d3705160b8f044a9ab21236b674e1a3bd295b8062beb79e91b7db34646a9cacL535-R550) [[3]](diffhunk://#diff-5d3705160b8f044a9ab21236b674e1a3bd295b8062beb79e91b7db34646a9cacL600-R618) [[4]](diffhunk://#diff-5d3705160b8f044a9ab21236b674e1a3bd295b8062beb79e91b7db34646a9cacR640-R641)

### Frontend changes:
* Removed unused state variable `showOutput` in `InputNode.tsx`.
* Corrected default value type from 'str' to 'string' in `InputNode.tsx`.
* Updated `NodeSidebar.tsx` to check for JSON output support and conditionally render schema editors and alerts. [[1]](diffhunk://#diff-bfbb4b8da1bcfb622620d5706176334f1a893d4dc5442ef0144bbf26e6162a26L491-R505) [[2]](diffhunk://#diff-bfbb4b8da1bcfb622620d5706176334f1a893d4dc5442ef0144bbf26e6162a26R517) [[3]](diffhunk://#diff-bfbb4b8da1bcfb622620d5706176334f1a893d4dc5442ef0144bbf26e6162a26R558-R584) [[4]](diffhunk://#diff-bfbb4b8da1bcfb622620d5706176334f1a893d4dc5442ef0144bbf26e6162a26R596) [[5]](diffhunk://#diff-bfbb4b8da1bcfb622620d5706176334f1a893d4dc5442ef0144bbf26e6162a26R634-R641)
* Added `supports_JSON_output` attribute to `ModelConstraints` in `nodeTypesSlice.ts`.