### PR TITLE
bugfix: add curl to backend container for the ollama check

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.12-slim AS base
 RUN apt-get update && apt-get install -y \
     libpq-dev \
     gcc \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /pyspur/backend


### PR DESCRIPTION
test-ollama.sh depends on curl. This patch Includes it in the backend container.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `curl` to `backend/Dockerfile` to support `test-ollama.sh` script execution.
> 
>   - **Dockerfile Update**:
>     - Add `curl` installation to `backend/Dockerfile` to support `test-ollama.sh` script execution.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for ab9d2cab372454e5ca019f7cee42c2acae3c1dbc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->