### PR TITLE
bugfix: change output schema str type to string

### DIFF
--- a/backend/templates/joke_generator.json
+++ b/backend/templates/joke_generator.json
@@ -13,8 +13,8 @@
         "node_type": "InputNode",
         "config": {
           "output_schema": {
-            "topic": "str",
-            "audience": "str"
+            "topic": "string",
+            "audience": "string"
           }
         },
         "coordinates": {
@@ -29,7 +29,7 @@
         "config": {
           "title": "JokeDrafter",
           "output_schema": {
-            "initial_joke": "str"
+            "initial_joke": "string"
           },
           "llm_info": {
             "model": "gpt-4o",
@@ -57,7 +57,7 @@
         "config": {
           "title": "JokeRefiner",
           "output_schema": {
-            "final_joke": "str"
+            "final_joke": "string"
           },
           "llm_info": {
             "model": "gpt-4o",
@@ -85,7 +85,7 @@
         "config": {
           "title": "SingleShotJoke",
           "output_schema": {
-            "final_joke": "str"
+            "final_joke": "string"
           },
           "llm_info": {
             "model": "gpt-4o",


### PR DESCRIPTION
In the joke sample, if the output schema type is "str" this causes the frontend to fail for some reason. Changing it to "string" seems to keep it stable. I think it's because the frontend doesn't have "str" as a type (in the type dropdown)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change output schema type from 'str' to 'string' in `joke_generator.json` to fix frontend compatibility issues.
> 
>   - **Behavior**:
>     - Change output schema type from `str` to `string` in `joke_generator.json`.
>     - Affects `topic`, `audience`, `initial_joke`, and `final_joke` fields.
>   - **Files**:
>     - `joke_generator.json`: Updated output schema types for `InputNode`, `JokeDrafter`, `JokeRefiner`, and `SingleShotJoke`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for 2652eca9da62a0074945d92688b76d3cb6c9f5fa. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->