### PR TITLE
Refactor workflow deletion logic and relationships

### DIFF
--- a/backend/app/models/output_file_model.py
+++ b/backend/app/models/output_file_model.py
@@ -1,5 +1,5 @@
 from sqlalchemy import Computed, Integer, String, DateTime
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 from datetime import datetime, timezone
 from .base_model import BaseModel
 
@@ -20,4 +20,11 @@ class OutputFileModel(BaseModel):
         DateTime,
         default=datetime.now(timezone.utc),
         onupdate=datetime.now(timezone.utc),
+    )
+
+    run = relationship(
+        "RunModel",
+        back_populates="output_file",
+        single_parent=True,
+        cascade="all, delete-orphan",
     )

--- a/backend/app/models/run_model.py
+++ b/backend/app/models/run_model.py
@@ -57,15 +57,19 @@ class RunModel(BaseModel):
     output_file_id: Mapped[Optional[str]] = mapped_column(
         String, ForeignKey("output_files.id"), nullable=True
     )
-    tasks: Mapped[List["TaskModel"]] = relationship("TaskModel")
+    tasks: Mapped[List["TaskModel"]] = relationship(
+        "TaskModel", cascade="all, delete-orphan"
+    )
     parent_run: Mapped[Optional["RunModel"]] = relationship(
-        "RunModel", remote_side=[id], back_populates="subruns"
+        "RunModel",
+        remote_side=[id],
+        back_populates="subruns",
     )
     subruns: Mapped[List["RunModel"]] = relationship(
-        "RunModel", back_populates="parent_run"
+        "RunModel", back_populates="parent_run", cascade="all, delete-orphan"
     )
     output_file: Mapped[Optional["OutputFileModel"]] = relationship(
-        "OutputFileModel", backref="run"
+        "OutputFileModel", back_populates="run"
     )
 
     @property

--- a/backend/app/models/task_model.py
+++ b/backend/app/models/task_model.py
@@ -47,8 +47,10 @@ class TaskModel(BaseModel):
     subworkflow: Mapped[Optional[Any]] = mapped_column(JSON, nullable=True)
     subworkflow_output: Mapped[Optional[Any]] = mapped_column(JSON, nullable=True)
 
-    parent_task: Mapped[Optional["TaskModel"]] = relationship(
-        "TaskModel", remote_side=[id], backref="subtasks"
+    # Relationships
+    parent_task = relationship("TaskModel", remote_side=[id], back_populates="subtasks")
+    subtasks = relationship(
+        "TaskModel", back_populates="parent_task", cascade="all, delete-orphan"
     )
 
     @property

--- a/backend/app/models/workflow_model.py
+++ b/backend/app/models/workflow_model.py
@@ -32,4 +32,6 @@ class WorkflowModel(BaseModel):
         onupdate=datetime.now(timezone.utc),
     )
 
-    versions = relationship("WorkflowVersionModel", back_populates="workflow")
+    versions = relationship(
+        "WorkflowVersionModel", back_populates="workflow", cascade="all, delete-orphan"
+    )

--- a/backend/app/models/workflow_version_model.py
+++ b/backend/app/models/workflow_version_model.py
@@ -34,5 +34,5 @@ class WorkflowVersionModel(BaseModel):
     workflow = relationship("WorkflowModel", back_populates="versions")
 
     runs: Mapped[Optional[List["RunModel"]]] = relationship(
-        "RunModel", backref="workflow_version"
+        "RunModel", backref="workflow_version", cascade="all, delete-orphan"
     )


### PR DESCRIPTION
This commit refactors the delete_workflow function in workflow_management.py to improve the deletion logic and relationships. The changes include:
- Removing unnecessary imports and unused code
- Deleting associated runs and workflow versions using cascading
- Deleting associated test files
- Deleting the workflow using cascading

These changes enhance the workflow deletion process and ensure that all related records are properly deleted.

Related issue: #<issue_number>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `delete_workflow` to use cascading deletes and update model relationships for cascading in `workflow_management.py` and related models.
> 
>   - **Behavior**:
>     - Refactor `delete_workflow` in `workflow_management.py` to use cascading deletes for associated runs, workflow versions, and test files.
>     - Removes unused imports in `workflow_management.py`.
>   - **Models**:
>     - Add `cascade="all, delete-orphan"` to relationships in `RunModel`, `TaskModel`, `WorkflowModel`, and `WorkflowVersionModel` to ensure cascading deletes.
>     - Update `OutputFileModel` to include a relationship with `RunModel` with cascading deletes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for 4f5dacd7e3a3532b9f2a5b82a2c53168718c4781. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->