### PR TITLE
feat: add deepseek-r1 to the list of ollama models

### DIFF
--- a/backend/app/nodes/llm/_utils.py
+++ b/backend/app/nodes/llm/_utils.py
@@ -113,6 +113,7 @@ class LLMModels(str, Enum):
     OLLAMA_MISTRAL = "ollama/mistral"
     OLLAMA_CODELLAMA = "ollama/codellama"
     OLLAMA_MIXTRAL = "ollama/mixtral-8x7b-instruct-v0.1"
+    OLLAMA_DEEPSEEK_R1 = "ollama/deepseek-r1"
 
     @classmethod
     def get_model_info(cls, model_id: str) -> LLMModel:
@@ -323,6 +324,12 @@ class LLMModels(str, Enum):
                 id=cls.OLLAMA_MIXTRAL.value,
                 provider=LLMProvider.OLLAMA,
                 name="Mixtral 8x7B Instruct",
+                constraints=ModelConstraints(max_tokens=4096, max_temperature=2.0),
+            ),
+            cls.OLLAMA_DEEPSEEK_R1.value: LLMModel(
+                id=cls.OLLAMA_DEEPSEEK_R1.value,
+                provider=LLMProvider.OLLAMA,
+                name="Deepseek R1",
                 constraints=ModelConstraints(max_tokens=4096, max_temperature=2.0),
             ),
         }


### PR DESCRIPTION
Simple addition of deepseek-r1 (ollama) to the list of models for the LLM nodes.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `OLLAMA_DEEPSEEK_R1` to `LLMModels` enum and `get_model_info()` in `_utils.py`.
> 
>   - **Models**:
>     - Add `OLLAMA_DEEPSEEK_R1` to `LLMModels` enum in `_utils.py`.
>     - Add `OLLAMA_DEEPSEEK_R1` entry in `get_model_info()` method with constraints `max_tokens=4096` and `max_temperature=2.0`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for 96bb94ec161c1da55b0905488479b41c7f0fd3d3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->