### PR TITLE
Feat/cascading failures

### DIFF
--- a/backend/app/api/workflow_run.py
+++ b/backend/app/api/workflow_run.py
@@ -212,7 +212,6 @@ async def run_workflow_non_blocking(
                     if node.node_type == "InputNode"
                 )
                 outputs = await executor(run.initial_inputs[input_node.id])
-                print("Outputs:", outputs)
                 run.outputs = {k: v.model_dump() for k, v in outputs.items()}
                 run.status = RunStatus.COMPLETED
                 run.end_time = datetime.now(timezone.utc)

--- a/backend/app/api/workflow_run.py
+++ b/backend/app/api/workflow_run.py
@@ -212,6 +212,7 @@ async def run_workflow_non_blocking(
                     if node.node_type == "InputNode"
                 )
                 outputs = await executor(run.initial_inputs[input_node.id])
+                print("Outputs:", outputs)
                 run.outputs = {k: v.model_dump() for k, v in outputs.items()}
                 run.status = RunStatus.COMPLETED
                 run.end_time = datetime.now(timezone.utc)
@@ -419,7 +420,12 @@ def list_runs(
             failed_tasks = [
                 task for task in run.tasks if task.status == TaskStatus.FAILED
             ]
-            if failed_tasks:
+            running_and_pending_tasks = [
+                task
+                for task in run.tasks
+                if task.status in [TaskStatus.PENDING, TaskStatus.RUNNING]
+            ]
+            if failed_tasks and len(running_and_pending_tasks) == 0:
                 run.status = RunStatus.FAILED
                 db.commit()
                 db.refresh(run)

--- a/backend/app/execution/workflow_executor.py
+++ b/backend/app/execution/workflow_executor.py
@@ -16,6 +16,14 @@ from .task_recorder import TaskRecorder, TaskStatus
 from .workflow_execution_context import WorkflowExecutionContext
 
 
+class UpstreamFailure(Exception):
+    pass
+
+
+class UnconnectedNode(Exception):
+    pass
+
+
 class WorkflowExecutor:
     """
     Handles the execution of a workflow.

--- a/backend/app/execution/workflow_executor.py
+++ b/backend/app/execution/workflow_executor.py
@@ -276,6 +276,17 @@ class WorkflowExecutor:
             # Store output
             self._outputs[node_id] = output
             return output
+        except UpstreamFailure as e:
+            self._failed_nodes.add(node_id)
+            self._outputs[node_id] = None
+            if self.task_recorder:
+                self.task_recorder.update_task(
+                    node_id=node_id,
+                    status=TaskStatus.CANCELED,
+                    end_time=datetime.now(),
+                    error="Upstream failure",
+                )
+            raise e
         except Exception as e:
             error_msg = (
                 f"Node execution failed:\n"

--- a/backend/app/execution/workflow_executor.py
+++ b/backend/app/execution/workflow_executor.py
@@ -179,6 +179,12 @@ class WorkflowExecutor:
                 [output is None for output in predecessor_outputs]
             ):
                 self._outputs[node_id] = None
+                if self.task_recorder:
+                    self.task_recorder.update_task(
+                        node_id=node_id,
+                        status=TaskStatus.CANCELED,
+                        end_time=datetime.now(),
+                    )
                 return None
 
             # Get source handles mapping
@@ -203,7 +209,7 @@ class WorkflowExecutor:
                         if self.task_recorder:
                             self.task_recorder.update_task(
                                 node_id=node_id,
-                                status=TaskStatus.PENDING,
+                                status=TaskStatus.CANCELED,
                                 end_time=datetime.now(),
                             )
                         return None

--- a/backend/app/execution/workflow_executor.py
+++ b/backend/app/execution/workflow_executor.py
@@ -164,14 +164,7 @@ class WorkflowExecutor:
             if any(dep_id in self._failed_nodes for dep_id in dependency_ids):
                 print(f"Node {node_id} skipped due to upstream failure")
                 self._failed_nodes.add(node_id)
-                if self.task_recorder:
-                    self.task_recorder.update_task(
-                        node_id=node_id,
-                        status=TaskStatus.FAILED,
-                        end_time=datetime.now(),
-                        error="Upstream node failure",
-                    )
-                raise Exception("Upstream node failure")
+                raise UpstreamFailure(f"Node {node_id} skipped due to upstream failure")
 
             # Wait for dependencies
             predecessor_outputs: List[Optional[BaseNodeOutput]] = []
@@ -253,7 +246,7 @@ class WorkflowExecutor:
             # If node_input is empty, return None
             if not node_input:
                 self._outputs[node_id] = None
-                raise Exception("Node not connected to any predecessor nodes")
+                raise UnconnectedNode(f"Node {node_id} has no input")
 
             node_instance = NodeFactory.create_node(
                 node_name=node.title, node_type_name=node.node_type, config=node.config

--- a/backend/app/execution/workflow_executor.py
+++ b/backend/app/execution/workflow_executor.py
@@ -239,6 +239,13 @@ class WorkflowExecutor:
             # If node_input is empty, return None
             if not node_input:
                 self._outputs[node_id] = None
+                if self.task_recorder:
+                    self.task_recorder.update_task(
+                        node_id=node_id,
+                        status=TaskStatus.COMPLETED,
+                        end_time=datetime.now(),
+                        outputs={},
+                    )
                 return None
 
             node_instance = NodeFactory.create_node(

--- a/backend/app/execution/workflow_executor.py
+++ b/backend/app/execution/workflow_executor.py
@@ -239,14 +239,7 @@ class WorkflowExecutor:
             # If node_input is empty, return None
             if not node_input:
                 self._outputs[node_id] = None
-                if self.task_recorder:
-                    self.task_recorder.update_task(
-                        node_id=node_id,
-                        status=TaskStatus.COMPLETED,
-                        end_time=datetime.now(),
-                        outputs={},
-                    )
-                return None
+                raise Exception("Node not connected to any predecessor nodes")
 
             node_instance = NodeFactory.create_node(
                 node_name=node.title, node_type_name=node.node_type, config=node.config

--- a/backend/app/execution/workflow_executor.py
+++ b/backend/app/execution/workflow_executor.py
@@ -356,6 +356,10 @@ class WorkflowExecutor:
             if node.parent_id:
                 nodes_to_run.discard(node.id)
 
+        # drop outputs for nodes that need to be run
+        for node_id in nodes_to_run:
+            self._outputs.pop(node_id, None)
+
         # Start tasks for all nodes
         for node_id in nodes_to_run:
             self._get_async_task_for_node_execution(node_id)

--- a/frontend/src/components/nodes/DynamicNode.tsx
+++ b/frontend/src/components/nodes/DynamicNode.tsx
@@ -353,7 +353,7 @@ const DynamicNode: React.FC<DynamicNodeProps> = ({
                         {renderHandles()}
                     </div>
                     {nodeData.error && <NodeErrorDisplay error={nodeData.error} />}
-                    {displayOutput && <NodeOutputDisplay key="output-display" output={nodeData.run} />}
+                    {displayOutput && <NodeOutputDisplay key={`output-display-${id}`} output={nodeData.run} />}
                 </BaseNode>
             </div>
             <NodeOutputModal

--- a/frontend/src/components/nodes/InputNode.tsx
+++ b/frontend/src/components/nodes/InputNode.tsx
@@ -336,7 +336,7 @@ const InputNode: React.FC<InputNodeProps> = ({ id, data, readOnly = false, ...pr
                         {renderWorkflowInputs()}
                         {renderAddField()}
                     </div>
-                    {data.run && <NodeOutputDisplay output={data.run} />}
+                    {data.run && <NodeOutputDisplay output={data.run} key={`output-${id}`} />}
                 </div>
             </BaseNode>
         </div>

--- a/frontend/src/components/nodes/logic/RouterNode.tsx
+++ b/frontend/src/components/nodes/logic/RouterNode.tsx
@@ -686,7 +686,7 @@ export const RouterNode: React.FC<RouterNodeProps> = ({ id, data, readOnly = fal
                         </div>
                     ))}
             </div>
-            <NodeOutputDisplay output={data.run} />
+            <NodeOutputDisplay output={data.run} key={`output-${id}`} />
         </BaseNode>
     )
 }

--- a/frontend/src/hooks/useWorkflowExecution.ts
+++ b/frontend/src/hooks/useWorkflowExecution.ts
@@ -115,7 +115,16 @@ export const useWorkflowExecution = ({ onAlert }: UseWorkflowExecutionProps) => 
                     // Clear all intervals
                     statusIntervals.current.forEach((interval) => clearInterval(interval))
                     clearInterval(currentStatusInterval)
-                    onAlert('Workflow run failed.', 'danger')
+
+                    // Check if some tasks succeeded while others failed
+                    if (
+                        tasks.some((task) => task.status === 'COMPLETED') &&
+                        tasks.some((task) => task.status === 'FAILED')
+                    ) {
+                        onAlert('Workflow ran with some failed tasks.', 'warning')
+                    } else {
+                        onAlert('Workflow run failed.', 'danger')
+                    }
                     return
                 }
             } catch (error) {

--- a/frontend/src/hooks/useWorkflowExecution.ts
+++ b/frontend/src/hooks/useWorkflowExecution.ts
@@ -105,7 +105,11 @@ export const useWorkflowExecution = ({ onAlert }: UseWorkflowExecutionProps) => 
                     clearInterval(currentStatusInterval)
                     onAlert('Workflow run completed.', 'success')
                 }
-                if (statusResponse.status === 'FAILED' || tasks.some((task) => task.status === 'FAILED')) {
+                if (
+                    statusResponse.status === 'FAILED' ||
+                    (tasks.some((task) => task.status === 'FAILED') &&
+                        !tasks.some((task) => task.status === 'RUNNING' || task.status === 'PENDING'))
+                ) {
                     setIsRunning(false)
                     setCompletionPercentage(0)
                     // Clear all intervals


### PR DESCRIPTION
This pull request introduces several changes to improve error handling and status updates in the workflow execution and run management modules. The most important changes include adding new exception classes, updating status handling logic, and enhancing the frontend components to handle output displays more effectively.

### Error Handling Improvements:

* [`backend/app/execution/workflow_executor.py`](diffhunk://#diff-8dd10b9c91f03781032cea965cb1788a2d49b9fb01a800ac09a2a7b6654ecd68R19-R26): Added new exception classes `UpstreamFailure` and `UnconnectedNode` to handle specific error scenarios during node execution. Updated `_execute_node` method to raise these exceptions when appropriate and mark nodes as failed. [[1]](diffhunk://#diff-8dd10b9c91f03781032cea965cb1788a2d49b9fb01a800ac09a2a7b6654ecd68R19-R26) [[2]](diffhunk://#diff-8dd10b9c91f03781032cea965cb1788a2d49b9fb01a800ac09a2a7b6654ecd68L153-R194) [[3]](diffhunk://#diff-8dd10b9c91f03781032cea965cb1788a2d49b9fb01a800ac09a2a7b6654ecd68L228-R255) [[4]](diffhunk://#diff-8dd10b9c91f03781032cea965cb1788a2d49b9fb01a800ac09a2a7b6654ecd68R285-R295)

### Status Handling Enhancements:

* [`backend/app/api/run_management.py`](diffhunk://#diff-dc8c5522e7240f19620f8b8ba98fe3623cd35d007d701a04abf7e49e12bf112bR50-R62): Updated `get_run_status` and `list_runs` methods to check for failed tasks and update the run status to `FAILED` if no tasks are running or pending. [[1]](diffhunk://#diff-dc8c5522e7240f19620f8b8ba98fe3623cd35d007d701a04abf7e49e12bf112bR50-R62) [[2]](diffhunk://#diff-22e860e7d966f852157d6b851899e47fa3ae02edd17768d4dcd2b951944dd036L422-R428)
* [`frontend/src/hooks/useWorkflowExecution.ts`](diffhunk://#diff-33742275b345d738acf29b65b38e2766a241fa90a9024f70eb30c77448876450L108-R127): Enhanced the `useWorkflowExecution` hook to provide more detailed alerts when a workflow run has some failed tasks but still completed.

### Frontend Output Display Improvements:

* `frontend/src/components/nodes/DynamicNode.tsx`, `frontend/src/components/nodes/InputNode.tsx`, `frontend/src/components/nodes/logic/RouterNode.tsx`: Updated the `NodeOutputDisplay` component to include a unique key for each output display to ensure proper rendering. [[1]](diffhunk://#diff-9319ee5346cc7086a25e5b34b731977f0e408914f038ee01ce8423f1b63c8b61L356-R356) [[2]](diffhunk://#diff-598db77a2bfd14df44fbe3de06be6afcc9355874a65655acbac8db38a523f5d7L339-R339) [[3]](diffhunk://#diff-32fa68bd81e295710ccf58fc52b31a15196088905646e9528815a09c75870cf8L703-R703)

### Logging and Debugging:

* [`backend/app/api/workflow_run.py`](diffhunk://#diff-22e860e7d966f852157d6b851899e47fa3ae02edd17768d4dcd2b951944dd036R215): Added a print statement to log the outputs during the workflow task execution for debugging purposes.

These changes collectively enhance the robustness and user experience of the workflow execution system by improving error handling, status updates, and frontend output displays.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improve error handling, status updates, and frontend output display in workflow execution system.
> 
>   - **Error Handling**:
>     - Add `UpstreamFailure` and `UnconnectedNode` exceptions in `workflow_executor.py` to handle specific node execution errors.
>     - Update `_execute_node` in `workflow_executor.py` to raise new exceptions and mark nodes as failed.
>   - **Status Handling**:
>     - Update `get_run_status` and `list_runs` in `run_management.py` to set run status to `FAILED` if all tasks are failed and none are running or pending.
>     - Enhance `useWorkflowExecution` in `useWorkflowExecution.ts` to alert when some tasks fail but the workflow completes.
>   - **Frontend Output Display**:
>     - Update `NodeOutputDisplay` in `DynamicNode.tsx`, `InputNode.tsx`, and `RouterNode.tsx` to use unique keys for rendering.
>   - **Logging**:
>     - Add print statement in `workflow_run.py` to log outputs during task execution for debugging.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for ee67cb45039165bf43dc6de5ff00c28ae3d7bdd3. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->