### PR TITLE
Refactor/make output schema mandatory

### DIFF
--- a/backend/app/api/node_management.py
+++ b/backend/app/api/node_management.py
@@ -45,29 +45,6 @@ async def get_node_types() -> Dict[str, List[Dict[str, Any]]]:
                 "has_fixed_output": issubclass(node_class, FixedOutputBaseNode),
             }
 
-            # Add output schema to config for fixed output nodes
-            if issubclass(node_class, FixedOutputBaseNode) and hasattr(node_class, 'output_schema'):
-                if 'properties' not in config_schema:
-                    config_schema['properties'] = {}
-
-                # Get the output schema from the node class
-                output_schema_dict = {}
-                if hasattr(node_class, 'output_schema'):
-                    if isinstance(node_class.output_schema, property):
-                        # If it's a property, create an instance to get the schema
-                        node_instance = node_class(name="temp", config=node_class.config_model())
-                        output_schema_dict = node_instance.output_schema
-                    else:
-                        output_schema_dict = node_class.output_schema
-
-                config_schema['properties']['output_schema'] = {
-                    'type': 'object',
-                    'title': 'Output Schema',
-                    'description': 'Fixed output schema for this node',
-                    'default': output_schema_dict,
-                    'readOnly': True
-                }
-
             # Add model constraints if this is an LLM node
             if node_type.node_type_name in ["LLMNode", "SingleLLMCallNode"]:
                 model_constraints = {}

--- a/backend/app/nodes/base.py
+++ b/backend/app/nodes/base.py
@@ -273,6 +273,12 @@ class BaseNode(ABC):
 
 
 class FixedOutputBaseNodeConfig(BaseNodeConfig):
+    output_schema: Dict[str, str] = Field(
+        default={"output": "string"},
+        title="Output schema",
+        description="The schema for the output of the node",
+    )
+    has_fixed_output: bool = True
     pass
 
 
@@ -281,15 +287,9 @@ class FixedOutputBaseNode(BaseNode, ABC):
     config_model = FixedOutputBaseNodeConfig
     input_model = BaseNodeInput
     output_model = BaseNodeOutput
-    has_fixed_output = True
-
-    @property
-    @abstractmethod
-    def output_schema(self) -> Dict[str, str]:
-        pass
 
     def setup(self) -> None:
-        self.output_model = self.create_output_model_class(self.output_schema)
+        self.output_model = self.create_output_model_class(self.config.output_schema)
         super().setup()
 
     @abstractmethod

--- a/frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx
+++ b/frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx
@@ -565,7 +565,7 @@ const NodeSidebar: React.FC<NodeSidebarProps> = ({ nodeID }) => {
             // Get model constraints to check if JSON output is supported
             const modelConstraints = getModelConstraints(nodeSchema, currentNodeConfig?.llm_info?.model)
             const supportsJsonOutput = modelConstraints?.supports_JSON_output ?? true
-            const hasFixedOutput = Boolean(nodeSchema && 'has_fixed_output' in nodeSchema ? nodeSchema.has_fixed_output : false)
+            const hasFixedOutput = Boolean(currentNodeConfig?.has_fixed_output ?? false)
 
             return (
                 <div key={key} className="my-2">
@@ -665,7 +665,7 @@ const NodeSidebar: React.FC<NodeSidebarProps> = ({ nodeID }) => {
             // Get model constraints to check if JSON output is supported
             const modelConstraints = getModelConstraints(nodeSchema, currentNodeConfig?.llm_info?.model)
             const supportsJsonOutput = modelConstraints?.supports_JSON_output ?? true
-            const hasFixedOutput = Boolean(nodeSchema && 'has_fixed_output' in nodeSchema ? nodeSchema.has_fixed_output : false)
+            const hasFixedOutput = Boolean(currentNodeConfig?.has_fixed_output ?? false)
 
             return (
                 <div key={key}>
@@ -864,6 +864,10 @@ const NodeSidebar: React.FC<NodeSidebarProps> = ({ nodeID }) => {
         }
         if (key === 'output_map') {
             return renderOutputMapField(key, value, incomingSchema, handleInputChange)
+        }
+        if (key === 'has_fixed_output') {
+            // do not render this field
+            return null
         }
 
         // Handle other types (string, number, boolean, object)

--- a/frontend/src/store/nodeTypesSlice.ts
+++ b/frontend/src/store/nodeTypesSlice.ts
@@ -68,6 +68,7 @@ export interface FlowWorkflowNodeType {
         routes?: RouteCondition[]
         input_schema?: Record<string, string>
         output_schema?: Record<string, string>
+        has_fixed_schema?: boolean
         title?: string
         system_message?: string
         user_message?: string


### PR DESCRIPTION
output_schema is made part of the config like regular schemas.
has_fixed_schema is also made part of the config. NodeSidebar is configured to not render it.

### Refactoring Fixed Output Schema Handling:

* [`backend/app/api/node_management.py`](diffhunk://#diff-8530362023a872961ce5e4d0c9d6ddfe2b30aae467279ffffced9836d4fea768L48-L70): Removed the logic for adding the output schema to the configuration for fixed output nodes.
* [`backend/app/nodes/base.py`](diffhunk://#diff-42496992867651ac2a1d3ed4af031ad36e0b524c410b9a99aef11d078be0a4a5R276-R281): Added `output_schema` and `has_fixed_output` fields to `FixedOutputBaseNodeConfig` and removed the abstract `output_schema` property from `FixedOutputBaseNode`. Updated the `setup` method to use the new `output_schema` field. [[1]](diffhunk://#diff-42496992867651ac2a1d3ed4af031ad36e0b524c410b9a99aef11d078be0a4a5R276-R281) [[2]](diffhunk://#diff-42496992867651ac2a1d3ed4af031ad36e0b524c410b9a99aef11d078be0a4a5L284-R292)
* [`backend/app/nodes/llm/retriever.py`](diffhunk://#diff-3293ea8aeafc35981bd04af71b728789f87fa9b28b370efd5167a1d7951c6f6bR23-R54): Updated `RetrieverNodeConfig` to include the `output_schema` field and removed the redundant `output_schema` property from `RetrieverNode`. [[1]](diffhunk://#diff-3293ea8aeafc35981bd04af71b728789f87fa9b28b370efd5167a1d7951c6f6bR23-R54) [[2]](diffhunk://#diff-3293ea8aeafc35981bd04af71b728789f87fa9b28b370efd5167a1d7951c6f6bL55-R79)

### Code Readability Improvements:

* [`backend/app/nodes/llm/retriever.py`](diffhunk://#diff-3293ea8aeafc35981bd04af71b728789f87fa9b28b370efd5167a1d7951c6f6bL1-L4): Removed unused imports and reformatted code for better readability, including breaking long lines and adding newlines for separation. [[1]](diffhunk://#diff-3293ea8aeafc35981bd04af71b728789f87fa9b28b370efd5167a1d7951c6f6bL1-L4) [[2]](diffhunk://#diff-3293ea8aeafc35981bd04af71b728789f87fa9b28b370efd5167a1d7951c6f6bL79-R127) [[3]](diffhunk://#diff-3293ea8aeafc35981bd04af71b728789f87fa9b28b370efd5167a1d7951c6f6bL127-R159) [[4]](diffhunk://#diff-3293ea8aeafc35981bd04af71b728789f87fa9b28b370efd5167a1d7951c6f6bL151-R182)

### Frontend Updates:

* [`frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx`](diffhunk://#diff-bfbb4b8da1bcfb622620d5706176334f1a893d4dc5442ef0144bbf26e6162a26L568-R568): Updated the logic to determine if a node has a fixed output by checking `currentNodeConfig` instead of `nodeSchema`. Also, prevented rendering of the `has_fixed_output` field. [[1]](diffhunk://#diff-bfbb4b8da1bcfb622620d5706176334f1a893d4dc5442ef0144bbf26e6162a26L568-R568) [[2]](diffhunk://#diff-bfbb4b8da1bcfb622620d5706176334f1a893d4dc5442ef0144bbf26e6162a26L668-R668) [[3]](diffhunk://#diff-bfbb4b8da1bcfb622620d5706176334f1a893d4dc5442ef0144bbf26e6162a26R868-R871)
* [`frontend/src/store/nodeTypesSlice.ts`](diffhunk://#diff-33ec26e74534da595f2b2c61ded78ec7b9e000953d236e4b5a2350dc58da75efR71): Added the `has_fixed_schema` field to the `FlowWorkflowNodeType` interface.