### PR TITLE
adding a logging configuration file

### DIFF
--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -9,7 +9,7 @@ fi
 set -e 
 mkdir -p /pyspur/backend/app/models/management/alembic/versions/
 start_server() {
-    uvicorn app.api.main:app --reload --host 0.0.0.0 --port 8000
+    uvicorn app.api.main:app --reload --reload-include ./log_conf.yaml --reload-include **/*.py --log-config=log_conf.yaml  --host 0.0.0.0 --port 8000
 }
 
 main() {

--- a/backend/log_conf.yaml
+++ b/backend/log_conf.yaml
@@ -1,0 +1,54 @@
+version: 1
+disable_existing_loggers: True
+formatters:
+  default:
+    # "()": uvicorn.logging.DefaultFormatter
+    format: '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+  access:
+    # "()": uvicorn.logging.AccessFormatter
+    format: '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+handlers:
+  default:
+    formatter: default
+    class: logging.StreamHandler
+    stream: ext://sys.stderr
+  access:
+    formatter: access
+    class: logging.StreamHandler
+    stream: ext://sys.stdout
+loggers:
+  uvicorn.error:
+    level: INFO
+    handlers:
+      - default
+    propagate: no
+  uvicorn.access:
+    level: INFO
+    handlers:
+      - access
+    propagate: no
+  httpx:
+    level: ERROR
+    handlers:
+      - default
+  httpcore:
+    level: ERROR
+    handlers:
+      - default
+  watchfiles.main:
+    level: INFO
+    handlers:
+      - default
+  LiteLLM:
+    level: INFO
+    handlers:
+      - default
+  openai._base_client:
+    level: INFO
+    handlers:
+      - default
+root:
+  level: DEBUG
+  handlers:
+    - default
+  propagate: no


### PR DESCRIPTION
During development there is a lot of noise, and on the other hand, when debugging workflows and dependencies (litellm, etc) it would be helpful to control the log output just to see whats actually being sent via APIs to openai/ollama, etc. This helps a lot.

I cannot move the log_conf.yaml to the root of the project. I tried mounting it, in a similar way as .env is mounted into the backend volume. However, watchfiles (used by uvicorn) doesn't seem to track any changes to auto-restart the server. Hence I've placed it within the backend directory for now.