### PR TITLE
get the ollama base URL from the environment if none has been defined

### DIFF
--- a/backend/app/nodes/llm/_utils.py
+++ b/backend/app/nodes/llm/_utils.py
@@ -603,6 +603,8 @@ async def generate_text(
 
     if json_mode and supports_json:
         if model_name.startswith("ollama"):
+            if api_base is None:
+                api_base = os.getenv('OLLAMA_BASE_URL')
             options = OllamaOptions(temperature=temperature, max_tokens=max_tokens)
             raw_response = await ollama_with_backoff(
                 model=model_name,


### PR DESCRIPTION
Fixes #118 

This code was removed from some reason, without any equivalent

https://github.com/PySpur-Dev/pyspur/commit/e20ef525ae58f2fe624a612d801f494d5c764546#diff-d30d48eb6ec8bc9deb473394df8e7e1e81ddb1c64d5de242c4b9b1534731f425R83
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds fallback to use `OLLAMA_BASE_URL` from environment in `generate_text()` if `api_base` is not provided for Ollama models.
> 
>   - **Behavior**:
>     - In `generate_text()` in `_utils.py`, if `api_base` is `None` and `model_name` starts with "ollama", set `api_base` to `os.getenv('OLLAMA_BASE_URL')`.
>   - **Misc**:
>     - Fixes missing environment variable fallback for Ollama API base URL.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for ca6ab245f78d79d5bbeb1f8bfdf64bd7cb126970. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->