### PR TITLE
Fix/for loop input

### DIFF
--- a/frontend/src/components/nodes/loops/DynamicGroupNode.tsx
+++ b/frontend/src/components/nodes/loops/DynamicGroupNode.tsx
@@ -102,8 +102,8 @@ const DynamicGroupNode: React.FC<DynamicGroupNodeProps> = ({ id }) => {
 
     // Keep input node's output schema in sync with parent's input_map
     useEffect(() => {
-        const inputNodeId = `${id}_input`
-        const inputNode = nodes.find((n) => n.id === inputNodeId)
+        // Find the input node by type and parent relationship
+        const inputNode = nodes.find((n) => n.type === 'InputNode' && n.parentId === id)
         if (inputNode && nodeConfig?.input_map) {
             // Build output schema by looking up the actual types from source nodes
             const derivedSchema: Record<string, string> = {}
@@ -127,11 +127,11 @@ const DynamicGroupNode: React.FC<DynamicGroupNodeProps> = ({ id }) => {
             })
 
             // Only update if the schema has actually changed
-            const inputNodeConfig = nodeConfigs[inputNodeId]
+            const inputNodeConfig = nodeConfigs[inputNode.id]
             if (!isEqual(inputNodeConfig?.output_schema, derivedSchema)) {
                 dispatch(
                     updateNodeConfigOnly({
-                        id: inputNodeId,
+                        id: inputNode.id,
                         data: {
                             output_schema: derivedSchema,
                             has_fixed_output: true,

--- a/frontend/src/components/nodes/loops/groupNodeUtils.ts
+++ b/frontend/src/components/nodes/loops/groupNodeUtils.ts
@@ -237,12 +237,13 @@ export const createDynamicGroupNodeWithChildren = (
             loopNodeAndConfig.node.id
         )
 
-        // Set input node's output schema to be tied to parent's input_map
+        // Set input node's output schema to be fixed but empty initially
+        // It will be populated reactively based on the parent's input_map
         if (inputNodeAndConfig) {
             inputNodeAndConfig.config = {
                 ...inputNodeAndConfig.config,
                 has_fixed_output: true, // Make output schema non-editable
-                output_schema: loopNodeAndConfig.config.input_map || {}, // Initialize from parent's input_map
+                output_schema: {}, // Empty initially, will be populated reactively
             }
         }
 

--- a/frontend/src/components/nodes/loops/groupNodeUtils.ts
+++ b/frontend/src/components/nodes/loops/groupNodeUtils.ts
@@ -1,14 +1,14 @@
 import { type Node, type NodeOrigin, type Rect, Box, Edge } from '@xyflow/react'
 // @todo import from @xyflow/react when fixed
-import { boxToRect, getNodePositionWithOrigin, rectToBox } from '@xyflow/system'
 import { Dispatch } from '@reduxjs/toolkit'
+import { boxToRect, getNodePositionWithOrigin, rectToBox } from '@xyflow/system'
 import { updateNodeParentAndCoordinates } from '../../../store/flowSlice'
 // Add MouseEvent from React
-import { MouseEvent as ReactMouseEvent } from 'react'
-import { FlowWorkflowNodeTypesByCategory } from '@/store/nodeTypesSlice'
-import { createNode } from '@/utils/nodeFactory'
-import { AppDispatch } from '@/store/store'
 import { addNodeWithConfig } from '@/store/flowSlice'
+import { FlowWorkflowNodeTypesByCategory } from '@/store/nodeTypesSlice'
+import { AppDispatch } from '@/store/store'
+import { createNode } from '@/utils/nodeFactory'
+import { MouseEvent as ReactMouseEvent } from 'react'
 
 export const GROUP_NODE_TYPES = ['ForLoopNode']
 
@@ -236,6 +236,15 @@ export const createDynamicGroupNodeWithChildren = (
             },
             loopNodeAndConfig.node.id
         )
+
+        // Set input node's output schema to be tied to parent's input_map
+        if (inputNodeAndConfig) {
+            inputNodeAndConfig.config = {
+                ...inputNodeAndConfig.config,
+                has_fixed_output: true, // Make output schema non-editable
+                output_schema: loopNodeAndConfig.config.input_map || {}, // Initialize from parent's input_map
+            }
+        }
 
         // Dispatch all nodes
         dispatch(addNodeWithConfig(loopNodeAndConfig))


### PR DESCRIPTION
## Synchronise Loop's InputNode's output_schema with Loop's input.

This pull request includes several updates to the `InputNode` and `DynamicGroupNode` components in the frontend codebase. The main changes involve improving the handling of fixed output schemas and ensuring synchronization between parent and child nodes.

### Enhancements to `InputNode` component:

* Added a check for `isFixedOutput` to prevent adding, deleting, or editing input variables when the output is fixed. [[1]](diffhunk://#diff-598db77a2bfd14df44fbe3de06be6afcc9355874a65655acbac8db38a523f5d7R38) [[2]](diffhunk://#diff-598db77a2bfd14df44fbe3de06be6afcc9355874a65655acbac8db38a523f5d7L60-R61) [[3]](diffhunk://#diff-598db77a2bfd14df44fbe3de06be6afcc9355874a65655acbac8db38a523f5d7L75-R89) [[4]](diffhunk://#diff-598db77a2bfd14df44fbe3de06be6afcc9355874a65655acbac8db38a523f5d7L100-R103) [[5]](diffhunk://#diff-598db77a2bfd14df44fbe3de06be6afcc9355874a65655acbac8db38a523f5d7L171-R174) [[6]](diffhunk://#diff-598db77a2bfd14df44fbe3de06be6afcc9355874a65655acbac8db38a523f5d7L213-R225) [[7]](diffhunk://#diff-598db77a2bfd14df44fbe3de06be6afcc9355874a65655acbac8db38a523f5d7L262-R270)

### Enhancements to `DynamicGroupNode` component:

* Introduced a new `useEffect` hook to keep the input node's output schema in sync with the parent's `input_map`. This ensures that the output schema is derived from the source nodes' output schemas.
* Updated the initial configuration of input nodes to have a fixed but empty output schema, which will be populated reactively based on the parent's `input_map`.

### Codebase improvements:

* Reorganized imports in `InputNode.tsx` and `DynamicGroupNode.tsx` for better readability and consistency. [[1]](diffhunk://#diff-598db77a2bfd14df44fbe3de06be6afcc9355874a65655acbac8db38a523f5d7L1-L17) [[2]](diffhunk://#diff-d78d5ccf5a5a650e3545d49e70e8f289b9c60b08c01427289b0a2b4c50b5b851R1) [[3]](diffhunk://#diff-d78d5ccf5a5a650e3545d49e70e8f289b9c60b08c01427289b0a2b4c50b5b851L14-R15)
* Added missing imports and reordered existing ones in `groupNodeUtils.ts` to follow a consistent structure.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Synchronize `InputNode` output schema with parent `DynamicGroupNode` input map, preventing modifications when output is fixed.
> 
>   - **Behavior**:
>     - `InputNode.tsx`: Added `isFixedOutput` check to prevent adding, deleting, or editing input variables when output is fixed.
>     - `DynamicGroupNode.tsx`: Added `useEffect` to sync input node's output schema with parent's `input_map`.
>     - `groupNodeUtils.ts`: Set input node's output schema to be fixed and empty initially, to be populated reactively.
>   - **Codebase Improvements**:
>     - Reorganized imports in `InputNode.tsx` and `DynamicGroupNode.tsx` for readability.
>     - Added missing imports and reordered existing ones in `groupNodeUtils.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for 938869ffe03ed62e77a0ad99646078d41fb67879. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->