### PR TITLE
Feat/structured output schema

### DIFF
--- a/backend/app/nodes/llm/_utils.py
+++ b/backend/app/nodes/llm/_utils.py
@@ -218,7 +218,7 @@ class LLMModels(str, Enum):
                 provider=LLMProvider.ANTHROPIC,
                 name="Claude 3.5 Sonnet Latest",
                 constraints=ModelConstraints(
-                    max_tokens=8192, max_temperature=1.0, supports_JSON_output=False
+                    max_tokens=8192, max_temperature=1.0,
                 ),
             ),
             cls.CLAUDE_3_5_HAIKU_LATEST.value: LLMModel(
@@ -226,7 +226,7 @@ class LLMModels(str, Enum):
                 provider=LLMProvider.ANTHROPIC,
                 name="Claude 3.5 Haiku Latest",
                 constraints=ModelConstraints(
-                    max_tokens=8192, max_temperature=1.0, supports_JSON_output=False
+                    max_tokens=8192, max_temperature=1.0,
                 ),
             ),
             cls.CLAUDE_3_OPUS_LATEST.value: LLMModel(
@@ -234,7 +234,7 @@ class LLMModels(str, Enum):
                 provider=LLMProvider.ANTHROPIC,
                 name="Claude 3 Opus Latest",
                 constraints=ModelConstraints(
-                    max_tokens=4096, max_temperature=1.0, supports_JSON_output=False
+                    max_tokens=4096, max_temperature=1.0,
                 ),
             ),
             # Google Models
@@ -571,7 +571,7 @@ async def generate_text(
         ):
             if litellm.supports_response_schema(
                 model=model_name, custom_llm_provider=model_info.provider
-            ):
+            ) or model_name.startswith("anthropic"):
                 if (
                     "name" not in output_json_schema
                     and "schema" not in output_json_schema


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removed JSON output support constraint for certain Anthropic models and updated `generate_text()` to handle JSON schema for these models in `_utils.py`.
> 
>   - **Behavior**:
>     - Removed `supports_JSON_output` constraint for `Claude 3.5 Sonnet Latest`, `Claude 3.5 Haiku Latest`, and `Claude 3 Opus Latest` models in `get_model_info()`.
>     - Updated `generate_text()` to allow models starting with "anthropic" to support response schema without checking `supports_response_schema()`.
>   - **Functions**:
>     - Modified `generate_text()` in `_utils.py` to handle JSON schema processing for models starting with "anthropic".
>   - **Misc**:
>     - Minor logic adjustment in `generate_text()` to streamline JSON schema handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for c9a6d6444a7700c72d8a9174334219d8446435ad. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->