### PR TITLE
Add Help Modal and Calendly Widget to Dashboard

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -40,14 +40,21 @@ import WelcomeModal from './modals/WelcomeModal'
 // Calendly Widget Component
 const CalendlyWidget: React.FC = () => {
     useEffect(() => {
-        // Load Calendly widget script
-        const script = document.createElement('script')
-        script.src = 'https://assets.calendly.com/assets/external/widget.js'
-        script.async = true
-        document.body.appendChild(script)
+        // Check if script already exists
+        const existingScript = document.querySelector(
+            'script[src="https://assets.calendly.com/assets/external/widget.js"]'
+        )
+        let scriptElement: HTMLScriptElement | null = null
 
-        // Initialize widget once script is loaded
-        script.onload = () => {
+        if (!existingScript) {
+            // Load Calendly widget script only if it doesn't exist
+            scriptElement = document.createElement('script')
+            scriptElement.src = 'https://assets.calendly.com/assets/external/widget.js'
+            scriptElement.async = true
+            document.body.appendChild(scriptElement)
+        }
+
+        const initializeWidget = () => {
             if ((window as any).Calendly) {
                 ;(window as any).Calendly.initBadgeWidget({
                     url: 'https://calendly.com/d/cnf9-57m-bv3/pyspur-founders',
@@ -58,9 +65,25 @@ const CalendlyWidget: React.FC = () => {
             }
         }
 
+        // Initialize widget once script is loaded or if it already exists
+        if (existingScript) {
+            initializeWidget()
+        } else if (scriptElement) {
+            scriptElement.onload = initializeWidget
+        }
+
         return () => {
-            // Cleanup
-            document.body.removeChild(script)
+            // Safe cleanup - only remove the script if we added it and it still exists
+            if (scriptElement && document.body.contains(scriptElement)) {
+                document.body.removeChild(scriptElement)
+            }
+            // Clean up the widget if it exists
+            if ((window as any).Calendly) {
+                const widgetElement = document.querySelector('.calendly-badge-widget')
+                if (widgetElement) {
+                    widgetElement.remove()
+                }
+            }
         }
     }, [])
 

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -16,6 +16,7 @@ import {
     getKeyValue,
 } from '@heroui/react'
 import { Icon } from '@iconify/react'
+import Head from 'next/head'
 import { useRouter } from 'next/router'
 import React, { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
@@ -35,6 +36,36 @@ import {
 } from '../utils/api'
 import TemplateCard from './cards/TemplateCard'
 import WelcomeModal from './modals/WelcomeModal'
+
+// Calendly Widget Component
+const CalendlyWidget: React.FC = () => {
+    useEffect(() => {
+        // Load Calendly widget script
+        const script = document.createElement('script')
+        script.src = 'https://assets.calendly.com/assets/external/widget.js'
+        script.async = true
+        document.body.appendChild(script)
+
+        // Initialize widget once script is loaded
+        script.onload = () => {
+            if ((window as any).Calendly) {
+                ;(window as any).Calendly.initBadgeWidget({
+                    url: 'https://calendly.com/d/cnf9-57m-bv3/pyspur-founders',
+                    text: 'Talk to the Founders',
+                    color: '#1a1a1a',
+                    textColor: '#ffffff',
+                })
+            }
+        }
+
+        return () => {
+            // Cleanup
+            document.body.removeChild(script)
+        }
+    }, [])
+
+    return null
+}
 
 const Dashboard: React.FC = () => {
     const router = useRouter()
@@ -277,6 +308,10 @@ const Dashboard: React.FC = () => {
 
     return (
         <div className="flex flex-col gap-2 max-w-7xl w-full mx-auto pt-2 px-6">
+            <Head>
+                <link href="https://assets.calendly.com/assets/external/widget.css" rel="stylesheet" />
+            </Head>
+            <CalendlyWidget />
             <WelcomeModal isOpen={showWelcome} onClose={() => setShowWelcome(false)} />
             <div>
                 {/* Dashboard Header */}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,34 +1,35 @@
-import React, { useState, useEffect } from 'react'
-import { useSelector, useDispatch } from 'react-redux'
 import {
+    Alert,
+    Button,
+    CircularProgress,
+    Dropdown,
+    DropdownItem,
+    DropdownMenu,
+    DropdownTrigger,
     Input,
+    Link,
     Navbar,
     NavbarBrand,
     NavbarContent,
     NavbarItem,
-    Link,
-    Button,
     Spinner,
-    Dropdown,
-    DropdownTrigger,
-    DropdownMenu,
-    DropdownItem,
-    Alert,
-    CircularProgress,
     Tooltip,
 } from '@heroui/react'
 import { Icon } from '@iconify/react'
-import SettingsCard from './modals/SettingsModal'
-import { setProjectName } from '../store/flowSlice'
-import RunModal from './modals/RunModal'
-import { getWorkflow } from '../utils/api'
-import { useRouter } from 'next/router'
-import DeployModal from './modals/DeployModal'
 import { formatDistanceStrict } from 'date-fns'
+import { useRouter } from 'next/router'
+import React, { useEffect, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
-import { useWorkflowExecution } from '../hooks/useWorkflowExecution'
-import { AlertState } from '../types/alert'
+import { useDispatch, useSelector } from 'react-redux'
 import { useSaveWorkflow } from '../hooks/useSaveWorkflow'
+import { useWorkflowExecution } from '../hooks/useWorkflowExecution'
+import { setProjectName } from '../store/flowSlice'
+import { AlertState } from '../types/alert'
+import { getWorkflow } from '../utils/api'
+import DeployModal from './modals/DeployModal'
+import HelpModal from './modals/HelpModal'
+import RunModal from './modals/RunModal'
+import SettingsCard from './modals/SettingsModal'
 
 interface HeaderProps {
     activePage: 'dashboard' | 'workflow' | 'evals' | 'trace' | 'rag'
@@ -52,6 +53,7 @@ const Header: React.FC<HeaderProps> = ({ activePage, associatedWorkflowId }) => 
     })
     const testInputs = useSelector((state: RootState) => state.flow.testInputs)
     const [selectedRow, setSelectedRow] = useState<number | null>(null)
+    const [isHelpModalOpen, setIsHelpModalOpen] = useState<boolean>(false)
 
     const router = useRouter()
     const { id } = router.query
@@ -278,13 +280,28 @@ const Header: React.FC<HeaderProps> = ({ activePage, associatedWorkflowId }) => 
                                             content={
                                                 <div className="px-1 py-2">
                                                     <div className="text-small font-bold">Run Workflow</div>
-                                                    <div className="text-tiny">Press <kbd>{navigator.platform.includes('Mac') ? '⌘ CMD' : 'Ctrl'}</kbd>+<kbd>Enter</kbd></div>
+                                                    <div className="text-tiny">
+                                                        Press{' '}
+                                                        <kbd>
+                                                            {navigator.platform.includes('Mac') ? '⌘ CMD' : 'Ctrl'}
+                                                        </kbd>
+                                                        +<kbd>Enter</kbd>
+                                                    </div>
                                                 </div>
                                             }
                                             placement="bottom"
                                         >
-                                            <Button isIconOnly radius="full" variant="light" onPress={handleRunWorkflow}>
-                                                <Icon className="text-foreground/60" icon="solar:play-linear" width={22} />
+                                            <Button
+                                                isIconOnly
+                                                radius="full"
+                                                variant="light"
+                                                onPress={handleRunWorkflow}
+                                            >
+                                                <Icon
+                                                    className="text-foreground/60"
+                                                    icon="solar:play-linear"
+                                                    width={22}
+                                                />
                                             </Button>
                                         </Tooltip>
                                     </NavbarItem>
@@ -361,6 +378,11 @@ const Header: React.FC<HeaderProps> = ({ activePage, associatedWorkflowId }) => 
                     <NavbarItem className="hidden sm:flex">
                         <SettingsCard />
                     </NavbarItem>
+                    <NavbarItem className="hidden sm:flex">
+                        <Button isIconOnly radius="full" variant="light" onPress={() => setIsHelpModalOpen(true)}>
+                            <Icon className="text-foreground/60" icon="solar:question-circle-linear" width={24} />
+                        </Button>
+                    </NavbarItem>
                 </NavbarContent>
             </Navbar>
             <RunModal
@@ -377,6 +399,7 @@ const Header: React.FC<HeaderProps> = ({ activePage, associatedWorkflowId }) => 
                 workflowId={workflowId}
                 testInput={testInputs.find((row) => row.id === selectedRow) ?? testInputs[0]}
             />
+            <HelpModal isOpen={isHelpModalOpen} onClose={() => setIsHelpModalOpen(false)} />
         </>
     )
 }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -379,7 +379,7 @@ const Header: React.FC<HeaderProps> = ({ activePage, associatedWorkflowId }) => 
                         <SettingsCard />
                     </NavbarItem>
                     <NavbarItem className="hidden sm:flex">
-                        <Button isIconOnly radius="full" variant="light" onPress={() => setIsHelpModalOpen(true)}>
+                        <Button isIconOnly radius="full" variant="light" onPress={() => setIsHelpModalOpen(true)} aria-label="Help">
                             <Icon className="text-foreground/60" icon="solar:question-circle-linear" width={24} />
                         </Button>
                     </NavbarItem>

--- a/frontend/src/components/modals/HelpModal.tsx
+++ b/frontend/src/components/modals/HelpModal.tsx
@@ -1,0 +1,59 @@
+import { Button, Card, CardBody, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader } from '@heroui/react'
+import { Icon } from '@iconify/react'
+
+interface HelpModalProps {
+    isOpen: boolean
+    onClose: () => void
+}
+
+export default function HelpModal({ isOpen, onClose }: HelpModalProps) {
+    return (
+        <Modal isOpen={isOpen} onClose={onClose} size="2xl">
+            <ModalContent>
+                <ModalHeader>How can we help you? 🤝</ModalHeader>
+                <ModalBody>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <Card
+                            className="cursor-pointer hover:scale-[1.02] transition-transform"
+                            isPressable
+                            onPress={() => window.open('https://calendly.com/d/cnf9-57m-bv3/pyspur-founders', '_blank')}
+                        >
+                            <CardBody className="flex flex-col items-center gap-4 p-6">
+                                <Icon icon="solar:calendar-linear" className="w-12 h-12 text-primary" />
+                                <div className="text-center">
+                                    <h3 className="text-lg font-semibold mb-2">Talk to the Founders</h3>
+                                    <p className="text-sm text-default-500">
+                                        Schedule a call with our founders to discuss your needs and get personalized
+                                        help
+                                    </p>
+                                </div>
+                            </CardBody>
+                        </Card>
+
+                        <Card
+                            className="cursor-pointer hover:scale-[1.02] transition-transform"
+                            isPressable
+                            onPress={() => window.open('https://github.com/pyspur-dev/pyspur', '_blank')}
+                        >
+                            <CardBody className="flex flex-col items-center gap-4 p-6">
+                                <Icon icon="solar:book-linear" className="w-12 h-12 text-primary" />
+                                <div className="text-center">
+                                    <h3 className="text-lg font-semibold mb-2">Documentation</h3>
+                                    <p className="text-sm text-default-500">
+                                        Browse our comprehensive documentation to learn more about PySpur&apos;s
+                                        features
+                                    </p>
+                                </div>
+                            </CardBody>
+                        </Card>
+                    </div>
+                </ModalBody>
+                <ModalFooter>
+                    <Button color="danger" variant="light" onPress={onClose}>
+                        Close
+                    </Button>
+                </ModalFooter>
+            </ModalContent>
+        </Modal>
+    )
+}


### PR DESCRIPTION
Introduce a Help Modal in the header for user assistance and integrate a Calendly widget on the dashboard for scheduling meetings with founders.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add Help Modal for user assistance and integrate Calendly widget for scheduling in the dashboard.
> 
>   - **Features**:
>     - Add `HelpModal` component in `HelpModal.tsx` for user assistance with options to schedule meetings or access documentation.
>     - Integrate `CalendlyWidget` in `Dashboard.tsx` to allow users to schedule meetings with founders.
>   - **UI Changes**:
>     - Add Help button in `Header.tsx` to open `HelpModal`.
>     - Add Calendly widget script and styles in `Dashboard.tsx`.
>   - **Code Structure**:
>     - Create `HelpModal.tsx` for the new modal component.
>     - Add `CalendlyWidget` component in `Dashboard.tsx` to manage Calendly script loading and widget initialization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for 1a5d06be8d899238a18b163441a1fbb7d1ec94d7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->