### PR TITLE
fix/ Router Node, Coalesce Node and Output Schemas

### DIFF
--- a/backend/app/execution/workflow_executor.py
+++ b/backend/app/execution/workflow_executor.py
@@ -234,6 +234,11 @@ class WorkflowExecutor:
             ):
                 self._outputs[node_id] = None
                 return None
+            elif node.node_type == "CoalesceNode" and all(
+                [v is None for v in node_input.values()]
+            ):
+                self._outputs[node_id] = None
+                return None
 
             # Remove None values from input
             node_input = {k: v for k, v in node_input.items() if v is not None}

--- a/frontend/src/components/nodes/logic/CoalesceNode.tsx
+++ b/frontend/src/components/nodes/logic/CoalesceNode.tsx
@@ -1,3 +1,4 @@
+import NodeErrorDisplay from '@/components/nodes/NodeErrorDisplay'
 import { FlowWorkflowNode } from '@/types/api_types/nodeTypeSchemas'
 import { Button, Card, Divider, Select, SelectItem } from '@heroui/react'
 import { Icon } from '@iconify/react'
@@ -37,6 +38,7 @@ export const CoalesceNode: React.FC<CoalesceNodeProps> = ({ id, data }) => {
 
     // Node's output for display
     const nodeOutput = useSelector((state: RootState) => state.flow.nodes.find((node) => node.id === id)?.data?.run)
+    const nodeError = useSelector((state: RootState) => state.flow.nodes.find((node) => node.id === id)?.data?.error)
 
     // Node's config
     const nodeConfig = useSelector((state: RootState) => state.flow.nodeConfigs[id])
@@ -384,7 +386,7 @@ export const CoalesceNode: React.FC<CoalesceNodeProps> = ({ id, data }) => {
                     </>
                 )}
             </div>
-
+            {nodeError && <NodeErrorDisplay error={nodeError} />}
             {/* Display node's output if it exists */}
             <NodeOutputDisplay output={nodeOutput} />
         </BaseNode>

--- a/frontend/src/components/nodes/logic/CoalesceNode.tsx
+++ b/frontend/src/components/nodes/logic/CoalesceNode.tsx
@@ -1,16 +1,15 @@
-import React, { useState, useRef, useEffect, useMemo } from 'react'
+import { FlowWorkflowNode } from '@/types/api_types/nodeTypeSchemas'
+import { Button, Card, Divider, Select, SelectItem } from '@heroui/react'
+import { Icon } from '@iconify/react'
 import { Handle, Position, useConnection } from '@xyflow/react'
-import BaseNode from '../BaseNode'
-import { Input, Card, Divider, Button, Select, SelectItem } from '@heroui/react'
+import isEqual from 'lodash/isEqual'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { updateNodeConfigOnly } from '../../../store/flowSlice'
-import styles from '../DynamicNode.module.css'
-import { Icon } from '@iconify/react'
 import { RootState } from '../../../store/store'
+import BaseNode from '../BaseNode'
+import styles from '../DynamicNode.module.css'
 import NodeOutputDisplay from '../NodeOutputDisplay'
-import isEqual from 'lodash/isEqual'
-import { FlowWorkflowNodeConfig } from '@/types/api_types/nodeTypeSchemas'
-import { FlowWorkflowNode } from '@/types/api_types/nodeTypeSchemas'
 
 interface CoalesceNodeProps {
     id: string
@@ -357,6 +356,9 @@ export const CoalesceNode: React.FC<CoalesceNodeProps> = ({ id, data }) => {
                                                     key={variable.value}
                                                     value={variable.value}
                                                     textValue={variable.label}
+                                                    classNames={{
+                                                        title: 'w-full whitespace-normal break-words',
+                                                    }}
                                                 >
                                                     <div className="whitespace-normal">
                                                         <span>{variable.label}</span>

--- a/frontend/src/components/nodes/logic/RouterNode.tsx
+++ b/frontend/src/components/nodes/logic/RouterNode.tsx
@@ -249,12 +249,21 @@ export const RouterNode: React.FC<RouterNodeProps> = ({ id, data, readOnly = fal
 
             const predNodeConfig = nodeConfigs[node.id]
             const nodeTitle = predNodeConfig?.title || node.id
-            const outputSchema = predNodeConfig?.output_schema || {}
+            const outputSchema = predNodeConfig?.output_json_schema || '{}'
 
-            return Object.entries(outputSchema).map(([key, type]) => ({
-                value: `${nodeTitle}.${key}`,
-                label: `${nodeTitle}.${key} (${type})`,
-            }))
+            try {
+                const schema = JSON.parse(outputSchema)
+                // Extract properties from JSON schema
+                const properties = schema.properties || {}
+
+                return Object.entries(properties).map(([key, value]: [string, any]) => ({
+                    value: `${nodeTitle}.${key}`,
+                    label: `${nodeTitle}.${key} (${value.type || 'any'})`,
+                }))
+            } catch (error) {
+                console.error('Failed to parse output schema:', error)
+                return []
+            }
         })
     }, [predecessorNodes, nodeConfigs])
 

--- a/frontend/src/components/nodes/logic/RouterNode.tsx
+++ b/frontend/src/components/nodes/logic/RouterNode.tsx
@@ -520,8 +520,7 @@ export const RouterNode: React.FC<RouterNodeProps> = ({ id, data, readOnly = fal
                                                         variant="flat"
                                                         classNames={{
                                                             trigger: 'dark:bg-default-50/10',
-                                                            base: 'dark:bg-default-50/10',
-                                                            popoverContent: 'dark:bg-default-50/10',
+                                                            popoverContent: 'dark:bg-default-50',
                                                         }}
                                                         renderValue={(items) => {
                                                             return items.map((item) => (
@@ -541,6 +540,9 @@ export const RouterNode: React.FC<RouterNodeProps> = ({ id, data, readOnly = fal
                                                                 value={variable.value}
                                                                 textValue={variable.label}
                                                                 className="text-default-700 dark:text-default-300"
+                                                                classNames={{
+                                                                    title: 'w-full whitespace-normal break-words',
+                                                                }}
                                                             >
                                                                 <div className="whitespace-normal">
                                                                     <span>{variable.label}</span>
@@ -579,8 +581,7 @@ export const RouterNode: React.FC<RouterNodeProps> = ({ id, data, readOnly = fal
                                                             variant="flat"
                                                             classNames={{
                                                                 trigger: 'dark:bg-default-50/10',
-                                                                base: 'dark:bg-default-50/10',
-                                                                popoverContent: 'dark:bg-default-50/10',
+                                                                popoverContent: 'dark:bg-default-50',
                                                             }}
                                                             renderValue={(items) => {
                                                                 return items.map((item) => (
@@ -599,6 +600,9 @@ export const RouterNode: React.FC<RouterNodeProps> = ({ id, data, readOnly = fal
                                                                     value={op.value}
                                                                     textValue={op.label}
                                                                     className="text-default-700 dark:text-default-300"
+                                                                    classNames={{
+                                                                        title: 'w-full whitespace-normal break-words',
+                                                                    }}
                                                                 >
                                                                     {op.label}
                                                                 </SelectItem>

--- a/frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx
+++ b/frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx
@@ -622,6 +622,11 @@ const NodeSidebar: React.FC<NodeSidebarProps> = ({ nodeID }) => {
         }
 
         if (key === 'output_json_schema') {
+            const isReadOnly =
+                currentNodeConfig?.has_fixed_output ||
+                (currentNodeConfig?.llm_info?.model && !currentModelConstraints?.supports_JSON_output) ||
+                node.type === 'RouterNode' ||
+                false
             return (
                 <div key={key}>
                     <div className="flex items-center gap-2 mb-2">
@@ -631,10 +636,10 @@ const NodeSidebar: React.FC<NodeSidebarProps> = ({ nodeID }) => {
                                 currentNodeConfig?.has_fixed_output === true
                                     ? "This node has a fixed output schema that cannot be modified. The JSON schema provides detailed validation rules for the node's output."
                                     : currentNodeConfig?.llm_info?.model &&
-                                        currentNodeConfig?.llm_info?.supports_JSON_output
+                                        currentModelConstraints?.supports_JSON_output
                                       ? "Define the structure of this node's output. You can use either the Simple Editor for basic types, or the JSON Schema Editor for more complex validation rules."
                                       : currentNodeConfig?.llm_info?.model &&
-                                          !currentNodeConfig?.llm_info?.supports_JSON_output
+                                          !currentModelConstraints?.supports_JSON_output
                                         ? "This model only supports a fixed output schema with a single 'output' field of type string. Schema editing is disabled."
                                         : "The output schema defines the structure of this node's output."
                             }
@@ -677,7 +682,7 @@ const NodeSidebar: React.FC<NodeSidebarProps> = ({ nodeID }) => {
                     <OutputSchemaEditor
                         nodeID={nodeID}
                         schema={currentNodeConfig.output_json_schema || ''}
-                        readOnly={currentNodeConfig?.has_fixed_output || false}
+                        readOnly={isReadOnly}
                         error={jsonSchemaError}
                         onChange={(newSchema) => {
                             handleInputChange('output_json_schema', newSchema)

--- a/frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx
+++ b/frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx
@@ -623,18 +623,69 @@ const NodeSidebar: React.FC<NodeSidebarProps> = ({ nodeID }) => {
 
         if (key === 'output_json_schema') {
             return (
-                <OutputSchemaEditor
-                    key={key}
-                    nodeID={nodeID}
-                    currentNodeConfig={currentNodeConfig}
-                    jsonSchemaError={jsonSchemaError}
-                    handleInputChange={handleInputChange}
-                    debouncedValidate={debouncedValidate}
-                    setCurrentNodeConfig={setCurrentNodeConfig}
-                    dispatch={dispatch}
-                    updateNodeConfigOnly={updateNodeConfigOnly}
-                    isLast={isLast}
-                />
+                <div key={key}>
+                    <div className="flex items-center gap-2 mb-2">
+                        <h3 className="font-semibold">Output Schema</h3>
+                        <Tooltip
+                            content={
+                                currentNodeConfig?.has_fixed_output === true
+                                    ? "This node has a fixed output schema that cannot be modified. The JSON schema provides detailed validation rules for the node's output."
+                                    : currentNodeConfig?.llm_info?.model &&
+                                        currentNodeConfig?.llm_info?.supports_JSON_output
+                                      ? "Define the structure of this node's output. You can use either the Simple Editor for basic types, or the JSON Schema Editor for more complex validation rules."
+                                      : currentNodeConfig?.llm_info?.model &&
+                                          !currentNodeConfig?.llm_info?.supports_JSON_output
+                                        ? "This model only supports a fixed output schema with a single 'output' field of type string. Schema editing is disabled."
+                                        : "The output schema defines the structure of this node's output."
+                            }
+                            placement="left-start"
+                            showArrow={true}
+                            className="max-w-xs"
+                        >
+                            <Icon
+                                icon="solar:question-circle-linear"
+                                className="text-default-400 cursor-help"
+                                width={20}
+                            />
+                        </Tooltip>
+                        {!currentNodeConfig?.has_fixed_output && currentNodeConfig?.llm_info?.model && (
+                            <Button
+                                isIconOnly
+                                radius="full"
+                                variant="light"
+                                size="sm"
+                                onClick={() => {
+                                    const defaultSchema = {
+                                        type: 'object',
+                                        properties: {
+                                            output: { type: 'string' },
+                                        },
+                                        required: ['output'],
+                                    }
+                                    handleInputChange('output_json_schema', JSON.stringify(defaultSchema, null, 2))
+                                }}
+                            >
+                                <Icon icon="solar:restart-linear" width={20} />
+                            </Button>
+                        )}
+                    </div>
+                    {currentNodeConfig?.has_fixed_output && (
+                        <p className="text-sm text-default-500 mb-2">
+                            This node has a fixed output schema that cannot be modified.
+                        </p>
+                    )}
+                    <OutputSchemaEditor
+                        nodeID={nodeID}
+                        schema={currentNodeConfig.output_json_schema || ''}
+                        readOnly={currentNodeConfig?.has_fixed_output || false}
+                        error={jsonSchemaError}
+                        onChange={(newSchema) => {
+                            handleInputChange('output_json_schema', newSchema)
+                            debouncedValidate(newSchema)
+                        }}
+                    />
+                    {!isLast && <hr className="my-2" />}
+                </div>
             )
         }
 

--- a/frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx
+++ b/frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx
@@ -626,6 +626,7 @@ const NodeSidebar: React.FC<NodeSidebarProps> = ({ nodeID }) => {
                 currentNodeConfig?.has_fixed_output ||
                 (currentNodeConfig?.llm_info?.model && !currentModelConstraints?.supports_JSON_output) ||
                 node.type === 'RouterNode' ||
+                node.type === 'CoalesceNode' ||
                 false
             return (
                 <div key={key}>

--- a/frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx
+++ b/frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx
@@ -833,19 +833,7 @@ const NodeSidebar: React.FC<NodeSidebarProps> = ({ nodeID }) => {
                             </Tabs>
                         </>
                     ) : (
-                        <Alert color="warning">
-                            <div className="flex items-center gap-2">
-                                <Icon icon="solar:info-circle-linear" width={20} />
-                                <span>
-                                    This model uses a fixed output schema:{' '}
-                                    <code>
-                                        {
-                                            "{ type: 'object', properties: { output: { type: 'string' } }, required: ['output'] }"
-                                        }
-                                    </code>
-                                </span>
-                            </div>
-                        </Alert>
+                        <></>
                     )}
                     {!isLast && <hr className="my-2" />}
                 </div>
@@ -916,9 +904,10 @@ const NodeSidebar: React.FC<NodeSidebarProps> = ({ nodeID }) => {
         }
 
         if (key.endsWith('_template')) {
-            const title = key.slice(0, -9)
+            const title = key
+                .slice(0, -9)
                 .replace(/_/g, ' ')
-                .replace(/\b\w/g, (char) => char.toUpperCase());
+                .replace(/\b\w/g, (char) => char.toUpperCase())
             return (
                 <div key={key}>
                     <div className="flex items-center gap-2 mb-2">
@@ -936,13 +925,11 @@ const NodeSidebar: React.FC<NodeSidebarProps> = ({ nodeID }) => {
                     />
                     {!isLast && <hr className="my-2" />}
                 </div>
-            );
+            )
         }
 
         if (key.endsWith('_prompt') || key.endsWith('_message')) {
-            const title = key
-                .replace(/_/g, ' ')
-                .replace(/\b\w/g, (char) => char.toUpperCase());
+            const title = key.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase())
             return (
                 <div key={key}>
                     <div className="flex items-center gap-2 mb-2">
@@ -959,7 +946,7 @@ const NodeSidebar: React.FC<NodeSidebarProps> = ({ nodeID }) => {
                     />
                     {!isLast && <hr className="my-2" />}
                 </div>
-            );
+            )
         }
 
         if (key === 'code') {

--- a/frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx
+++ b/frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx
@@ -5,15 +5,12 @@ import {
     Alert,
     Button,
     Card,
-    CardBody,
     Input,
     Select,
     SelectItem,
     SelectSection,
     Slider,
     Switch,
-    Tab,
-    Tabs,
     Textarea,
     Tooltip,
 } from '@heroui/react'
@@ -43,6 +40,7 @@ import NumberInput from '../../NumberInput'
 import FewShotEditor from '../../textEditor/FewShotEditor'
 import TextEditor from '../../textEditor/TextEditor'
 import NodeOutput from '../NodeOutputDisplay'
+import OutputSchemaEditor from './OutputSchemaEditor'
 import SchemaEditor from './SchemaEditor'
 
 import { convertToPythonVariableName } from '@/utils/variableNameUtils'
@@ -691,156 +689,21 @@ const NodeSidebar: React.FC<NodeSidebarProps> = ({ nodeID }) => {
         }
 
         if (key === 'output_json_schema') {
-            const { schema: parsedSchema, error: parseError } = extractSchemaFromJsonSchema(
-                currentNodeConfig[key] || ''
-            )
-
             return (
-                <div key={key}>
-                    <div className="flex items-center gap-2 mb-2">
-                        <h3 className="font-semibold">Output Schema</h3>
-                        <Tooltip
-                            content={
-                                currentNodeConfig?.has_fixed_output === true
-                                    ? "This node has a fixed output schema that cannot be modified. The JSON schema provides detailed validation rules for the node's output."
-                                    : currentNodeConfig?.llm_info?.model &&
-                                        currentModelConstraints?.supports_JSON_output
-                                      ? "Define the structure of this node's output. You can use either the Simple Editor for basic types, or the JSON Schema Editor for more complex validation rules."
-                                      : currentNodeConfig?.llm_info?.model &&
-                                          !currentModelConstraints?.supports_JSON_output
-                                        ? "This model only supports a fixed output schema with a single 'output' field of type string. Schema editing is disabled."
-                                        : "The output schema defines the structure of this node's output."
-                            }
-                            placement="left-start"
-                            showArrow={true}
-                            className="max-w-xs"
-                        >
-                            <Icon
-                                icon="solar:question-circle-linear"
-                                className="text-default-400 cursor-help"
-                                width={20}
-                            />
-                        </Tooltip>
-                        {!currentNodeConfig?.has_fixed_output && currentNodeConfig?.llm_info?.model && (
-                            <Button
-                                isIconOnly
-                                radius="full"
-                                variant="light"
-                                size="sm"
-                                onClick={() => {
-                                    const defaultSchema = {
-                                        type: 'object',
-                                        properties: {
-                                            output: { type: 'string' },
-                                        },
-                                        required: ['output'],
-                                    }
-                                    handleInputChange('output_json_schema', JSON.stringify(defaultSchema, null, 2))
-                                }}
-                            >
-                                <Icon icon="solar:restart-linear" width={20} />
-                            </Button>
-                        )}
-                    </div>
-                    {currentNodeConfig?.has_fixed_output ? (
-                        <div className="bg-default-100 rounded-lg p-4">
-                            <CodeEditor
-                                key={`code-editor-output-json-schema-${nodeID}`}
-                                code={currentNodeConfig[key] || ''}
-                                mode="json"
-                                onChange={() => {}} // No-op for fixed output nodes
-                                readOnly={true}
-                            />
-                            <p className="text-sm text-default-500 mt-2">
-                                This node has a fixed output schema that cannot be modified.
-                            </p>
-                        </div>
-                    ) : currentNodeConfig?.llm_info?.model ? (
-                        <>
-                            {jsonSchemaError && (
-                                <Alert color="danger" className="mb-2">
-                                    <div className="flex items-center gap-2">
-                                        <span>{jsonSchemaError}</span>
-                                    </div>
-                                </Alert>
-                            )}
-                            <Tabs aria-label="Schema Editor Options" disabledKeys={jsonSchemaError ? ['simple'] : []}>
-                                <Tab key="simple" title="Simple Editor">
-                                    {parsedSchema && (
-                                        <Card>
-                                            <CardBody>
-                                                <SchemaEditor
-                                                    key={`schema-editor-output-${nodeID}`}
-                                                    jsonValue={parsedSchema}
-                                                    onChange={(newValue) => {
-                                                        if (typeof newValue === 'object' && !('type' in newValue)) {
-                                                            const jsonSchema = generateJsonSchemaFromSchema(newValue)
-                                                            if (jsonSchema) {
-                                                                const updates = {
-                                                                    output_json_schema: jsonSchema,
-                                                                }
-                                                                setCurrentNodeConfig((prev) => ({
-                                                                    ...prev,
-                                                                    ...updates,
-                                                                }))
-                                                                dispatch(
-                                                                    updateNodeConfigOnly({
-                                                                        id: nodeID,
-                                                                        data: {
-                                                                            ...currentNodeConfig,
-                                                                            ...updates,
-                                                                        },
-                                                                    })
-                                                                )
-                                                            }
-                                                        } else {
-                                                            const updates = {
-                                                                output_json_schema: JSON.stringify(newValue, null, 2),
-                                                            }
-                                                            setCurrentNodeConfig((prev) => ({
-                                                                ...prev,
-                                                                ...updates,
-                                                            }))
-                                                            dispatch(
-                                                                updateNodeConfigOnly({
-                                                                    id: nodeID,
-                                                                    data: {
-                                                                        ...currentNodeConfig,
-                                                                        ...updates,
-                                                                    },
-                                                                })
-                                                            )
-                                                        }
-                                                    }}
-                                                    options={jsonOptions}
-                                                    nodeId={nodeID}
-                                                />
-                                            </CardBody>
-                                        </Card>
-                                    )}
-                                </Tab>
-                                <Tab key="json" title="JSON Schema">
-                                    <Card>
-                                        <CardBody>
-                                            <CodeEditor
-                                                key={`code-editor-output-json-schema-${nodeID}`}
-                                                code={currentNodeConfig[key] || ''}
-                                                mode="json"
-                                                onChange={(value: string) => {
-                                                    handleInputChange('output_json_schema', value)
-                                                    debouncedValidate(value)
-                                                }}
-                                            />
-                                        </CardBody>
-                                    </Card>
-                                </Tab>
-                            </Tabs>
-                        </>
-                    ) : (
-                        <></>
-                    )}
-                    {!isLast && <hr className="my-2" />}
-                </div>
+                <OutputSchemaEditor
+                    key={key}
+                    nodeID={nodeID}
+                    currentNodeConfig={currentNodeConfig}
+                    jsonSchemaError={jsonSchemaError}
+                    handleInputChange={handleInputChange}
+                    debouncedValidate={debouncedValidate}
+                    setCurrentNodeConfig={setCurrentNodeConfig}
+                    dispatch={dispatch}
+                    updateNodeConfigOnly={updateNodeConfigOnly}
+                    generateJsonSchemaFromSchema={generateJsonSchemaFromSchema}
+                    extractSchemaFromJsonSchema={extractSchemaFromJsonSchema}
+                    isLast={isLast}
+                />
             )
         }
 

--- a/frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx
+++ b/frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx
@@ -703,9 +703,13 @@ const NodeSidebar: React.FC<NodeSidebarProps> = ({ nodeID }) => {
                             content={
                                 currentNodeConfig?.has_fixed_output === true
                                     ? "This node has a fixed output schema that cannot be modified. The JSON schema provides detailed validation rules for the node's output."
-                                    : currentNodeConfig?.llm_info?.model
+                                    : currentNodeConfig?.llm_info?.model &&
+                                        currentModelConstraints?.supports_JSON_output
                                       ? "Define the structure of this node's output. You can use either the Simple Editor for basic types, or the JSON Schema Editor for more complex validation rules."
-                                      : "This model only supports a fixed output schema with a single 'output' field of type string. Schema editing is disabled."
+                                      : currentNodeConfig?.llm_info?.model &&
+                                          !currentModelConstraints?.supports_JSON_output
+                                        ? "This model only supports a fixed output schema with a single 'output' field of type string. Schema editing is disabled."
+                                        : "The output schema defines the structure of this node's output."
                             }
                             placement="left-start"
                             showArrow={true}

--- a/frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx
+++ b/frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx
@@ -43,6 +43,7 @@ import NodeOutput from '../NodeOutputDisplay'
 import OutputSchemaEditor from './OutputSchemaEditor'
 import SchemaEditor from './SchemaEditor'
 
+import { extractSchemaFromJsonSchema, generateJsonSchemaFromSchema } from '@/utils/schemaUtils'
 import { convertToPythonVariableName } from '@/utils/variableNameUtils'
 import Ajv from 'ajv'
 
@@ -78,75 +79,7 @@ const nodesComparator = (prevNodes: FlowWorkflowNode[], nextNodes: FlowWorkflowN
     return prevNodes.every((node, index) => nodeComparator(node, nextNodes[index]))
 }
 
-// Update the extractSchemaFromJsonSchema function to return an error instead of calling setError
-const extractSchemaFromJsonSchema = (
-    jsonSchema: string
-): { schema: Record<string, any> | null; error: string | null } => {
-    if (!jsonSchema || !jsonSchema.trim()) {
-        return { schema: null, error: null }
-    }
-    try {
-        // Try to parse the schema
-        let parsed: Record<string, any>
-        try {
-            parsed = JSON.parse(jsonSchema.trim())
-        } catch (e: any) {
-            // If the schema has escaped characters, clean it up first
-            let cleaned = jsonSchema
-                .replace(/\"/g, '"') // Replace escaped quotes
-                .replace(/\\\[/g, '[') // Replace escaped brackets
-                .replace(/\\\]/g, ']')
-                .replace(/\\n/g, '') // Remove newlines
-                .replace(/\\t/g, '') // Remove tabs
-                .replace(/\\/g, '') // Remove remaining backslashes
-                .trim()
-            try {
-                parsed = JSON.parse(cleaned)
-            } catch (e: any) {
-                // Extract line and column info from the error message if available
-                const match = e.message.match(/at position (\d+)(?:\s*\(line (\d+) column (\d+)\))?/)
-                const errorMsg = match
-                    ? `Invalid JSON: ${e.message.split('at position')[0].trim()} at line ${match[2] || '?'}, column ${match[3] || '?'}`
-                    : `Invalid JSON: ${e.message}`
-                return { schema: null, error: errorMsg }
-            }
-        }
-
-        // If the parsed schema has a properties field (i.e. full JSON Schema format),
-        // return the nested properties so that nested objects are preserved.
-        if (parsed.properties) {
-            return { schema: parsed.properties, error: null }
-        }
-        return { schema: parsed, error: null }
-    } catch (error: any) {
-        return { schema: null, error: error.message || 'Invalid JSON Schema' }
-    }
-}
-
 // Add this helper function near the top, after extractSchemaFromJsonSchema
-const generateJsonSchemaFromSchema = (schema: Record<string, string>): string | null => {
-    if (!schema || Object.keys(schema).length === 0) return null
-
-    try {
-        const jsonSchema = {
-            type: 'object',
-            required: Object.keys(schema),
-            properties: {} as Record<string, { type: string }>,
-        }
-
-        for (const [key, type] of Object.entries(schema)) {
-            if (!key || !type) return null
-            jsonSchema.properties[key] = { type }
-        }
-
-        return JSON.stringify(jsonSchema, null, 2)
-    } catch (error) {
-        console.error('Error generating JSON schema:', error)
-        return null
-    }
-}
-
-// Add this function after the existing helper functions and before the NodeSidebar component
 const getModelConstraints = (nodeSchema: FlowWorkflowNodeType | null, modelId: string): ModelConstraints | null => {
     if (!nodeSchema || !nodeSchema.model_constraints || !nodeSchema.model_constraints[modelId]) {
         return null
@@ -700,8 +633,6 @@ const NodeSidebar: React.FC<NodeSidebarProps> = ({ nodeID }) => {
                     setCurrentNodeConfig={setCurrentNodeConfig}
                     dispatch={dispatch}
                     updateNodeConfigOnly={updateNodeConfigOnly}
-                    generateJsonSchemaFromSchema={generateJsonSchemaFromSchema}
-                    extractSchemaFromJsonSchema={extractSchemaFromJsonSchema}
                     isLast={isLast}
                 />
             )

--- a/frontend/src/components/nodes/nodeSidebar/OutputSchemaEditor.tsx
+++ b/frontend/src/components/nodes/nodeSidebar/OutputSchemaEditor.tsx
@@ -2,6 +2,7 @@ import { Alert, Button, Card, CardBody, Tab, Tabs, Tooltip } from '@heroui/react
 import { Icon } from '@iconify/react'
 import React from 'react'
 import { jsonOptions } from '../../../constants/jsonOptions'
+import { extractSchemaFromJsonSchema, generateJsonSchemaFromSchema } from '../../../utils/schemaUtils'
 import CodeEditor from '../../CodeEditor'
 import SchemaEditor from './SchemaEditor'
 
@@ -14,8 +15,6 @@ interface OutputSchemaEditorProps {
     setCurrentNodeConfig: (updater: (prev: any) => any) => void
     dispatch: any
     updateNodeConfigOnly: any
-    generateJsonSchemaFromSchema: (schema: Record<string, string>) => string | null
-    extractSchemaFromJsonSchema: (jsonSchema: string) => { schema: Record<string, any> | null; error: string | null }
     isLast?: boolean
 }
 
@@ -28,8 +27,6 @@ const OutputSchemaEditor: React.FC<OutputSchemaEditorProps> = ({
     setCurrentNodeConfig,
     dispatch,
     updateNodeConfigOnly,
-    generateJsonSchemaFromSchema,
-    extractSchemaFromJsonSchema,
     isLast = false,
 }) => {
     const { schema: parsedSchema } = extractSchemaFromJsonSchema(currentNodeConfig.output_json_schema || '')

--- a/frontend/src/components/nodes/nodeSidebar/OutputSchemaEditor.tsx
+++ b/frontend/src/components/nodes/nodeSidebar/OutputSchemaEditor.tsx
@@ -1,5 +1,4 @@
-import { Alert, Button, Card, CardBody, Tab, Tabs, Tooltip } from '@heroui/react'
-import { Icon } from '@iconify/react'
+import { Alert, Card, CardBody, Tab, Tabs } from '@heroui/react'
 import React from 'react'
 import { jsonOptions } from '../../../constants/jsonOptions'
 import { extractSchemaFromJsonSchema, generateJsonSchemaFromSchema } from '../../../utils/schemaUtils'
@@ -8,168 +7,80 @@ import SchemaEditor from './SchemaEditor'
 
 interface OutputSchemaEditorProps {
     nodeID: string
-    currentNodeConfig: any
-    jsonSchemaError: string
-    handleInputChange: (key: string, value: any) => void
-    debouncedValidate: (value: string) => void
-    setCurrentNodeConfig: (updater: (prev: any) => any) => void
-    dispatch: any
-    updateNodeConfigOnly: any
-    isLast?: boolean
+    schema: string
+    readOnly?: boolean
+    error?: string
+    onChange: (newSchema: string) => void
 }
 
 const OutputSchemaEditor: React.FC<OutputSchemaEditorProps> = ({
     nodeID,
-    currentNodeConfig,
-    jsonSchemaError,
-    handleInputChange,
-    debouncedValidate,
-    setCurrentNodeConfig,
-    dispatch,
-    updateNodeConfigOnly,
-    isLast = false,
+    schema,
+    readOnly = false,
+    error = '',
+    onChange,
 }) => {
-    const { schema: parsedSchema } = extractSchemaFromJsonSchema(currentNodeConfig.output_json_schema || '')
+    const { schema: parsedSchema } = extractSchemaFromJsonSchema(schema || '')
+
+    const handleSchemaEditorChange = (newValue: any) => {
+        if (!readOnly) {
+            if (typeof newValue === 'object' && !('type' in newValue)) {
+                const jsonSchema = generateJsonSchemaFromSchema(newValue)
+                if (jsonSchema) {
+                    onChange(jsonSchema)
+                }
+            } else {
+                onChange(JSON.stringify(newValue, null, 2))
+            }
+        }
+    }
+
+    const handleJsonEditorChange = (value: string) => {
+        if (!readOnly) {
+            onChange(value)
+        }
+    }
 
     return (
-        <div key="output_json_schema">
-            <div className="flex items-center gap-2 mb-2">
-                <h3 className="font-semibold">Output Schema</h3>
-                <Tooltip
-                    content={
-                        currentNodeConfig?.has_fixed_output === true
-                            ? "This node has a fixed output schema that cannot be modified. The JSON schema provides detailed validation rules for the node's output."
-                            : currentNodeConfig?.llm_info?.model && currentNodeConfig?.llm_info?.supports_JSON_output
-                              ? "Define the structure of this node's output. You can use either the Simple Editor for basic types, or the JSON Schema Editor for more complex validation rules."
-                              : currentNodeConfig?.llm_info?.model && !currentNodeConfig?.llm_info?.supports_JSON_output
-                                ? "This model only supports a fixed output schema with a single 'output' field of type string. Schema editing is disabled."
-                                : "The output schema defines the structure of this node's output."
-                    }
-                    placement="left-start"
-                    showArrow={true}
-                    className="max-w-xs"
-                >
-                    <Icon icon="solar:question-circle-linear" className="text-default-400 cursor-help" width={20} />
-                </Tooltip>
-                {!currentNodeConfig?.has_fixed_output && currentNodeConfig?.llm_info?.model && (
-                    <Button
-                        isIconOnly
-                        radius="full"
-                        variant="light"
-                        size="sm"
-                        onClick={() => {
-                            const defaultSchema = {
-                                type: 'object',
-                                properties: {
-                                    output: { type: 'string' },
-                                },
-                                required: ['output'],
-                            }
-                            handleInputChange('output_json_schema', JSON.stringify(defaultSchema, null, 2))
-                        }}
-                    >
-                        <Icon icon="solar:restart-linear" width={20} />
-                    </Button>
-                )}
-            </div>
-            {currentNodeConfig?.has_fixed_output ? (
-                <div className="bg-default-100 rounded-lg p-4">
-                    <CodeEditor
-                        key={`code-editor-output-json-schema-${nodeID}`}
-                        code={currentNodeConfig.output_json_schema || ''}
-                        mode="json"
-                        onChange={() => {}} // No-op for fixed output nodes
-                        readOnly={true}
-                    />
-                    <p className="text-sm text-default-500 mt-2">
-                        This node has a fixed output schema that cannot be modified.
-                    </p>
-                </div>
-            ) : currentNodeConfig?.llm_info?.model ? (
-                <>
-                    {jsonSchemaError && (
-                        <Alert color="danger" className="mb-2">
-                            <div className="flex items-center gap-2">
-                                <span>{jsonSchemaError}</span>
-                            </div>
-                        </Alert>
-                    )}
-                    <Tabs aria-label="Schema Editor Options" disabledKeys={jsonSchemaError ? ['simple'] : []}>
-                        <Tab key="simple" title="Simple Editor">
-                            {parsedSchema && (
-                                <Card>
-                                    <CardBody>
-                                        <SchemaEditor
-                                            key={`schema-editor-output-${nodeID}`}
-                                            jsonValue={parsedSchema}
-                                            onChange={(newValue) => {
-                                                if (typeof newValue === 'object' && !('type' in newValue)) {
-                                                    const jsonSchema = generateJsonSchemaFromSchema(newValue)
-                                                    if (jsonSchema) {
-                                                        const updates = {
-                                                            output_json_schema: jsonSchema,
-                                                        }
-                                                        setCurrentNodeConfig((prev) => ({
-                                                            ...prev,
-                                                            ...updates,
-                                                        }))
-                                                        dispatch(
-                                                            updateNodeConfigOnly({
-                                                                id: nodeID,
-                                                                data: {
-                                                                    ...currentNodeConfig,
-                                                                    ...updates,
-                                                                },
-                                                            })
-                                                        )
-                                                    }
-                                                } else {
-                                                    const updates = {
-                                                        output_json_schema: JSON.stringify(newValue, null, 2),
-                                                    }
-                                                    setCurrentNodeConfig((prev) => ({
-                                                        ...prev,
-                                                        ...updates,
-                                                    }))
-                                                    dispatch(
-                                                        updateNodeConfigOnly({
-                                                            id: nodeID,
-                                                            data: {
-                                                                ...currentNodeConfig,
-                                                                ...updates,
-                                                            },
-                                                        })
-                                                    )
-                                                }
-                                            }}
-                                            options={jsonOptions}
-                                            nodeId={nodeID}
-                                        />
-                                    </CardBody>
-                                </Card>
-                            )}
-                        </Tab>
-                        <Tab key="json" title="JSON Schema">
-                            <Card>
-                                <CardBody>
-                                    <CodeEditor
-                                        key={`code-editor-output-json-schema-${nodeID}`}
-                                        code={currentNodeConfig.output_json_schema || ''}
-                                        mode="json"
-                                        onChange={(value: string) => {
-                                            handleInputChange('output_json_schema', value)
-                                            debouncedValidate(value)
-                                        }}
-                                    />
-                                </CardBody>
-                            </Card>
-                        </Tab>
-                    </Tabs>
-                </>
-            ) : (
-                <></>
+        <div>
+            {error && (
+                <Alert color="danger" className="mb-2">
+                    <div className="flex items-center gap-2">
+                        <span>{error}</span>
+                    </div>
+                </Alert>
             )}
-            {!isLast && <hr className="my-2" />}
+            <Tabs aria-label="Schema Editor Options" disabledKeys={error ? ['simple'] : []}>
+                <Tab key="simple" title="Simple Editor">
+                    {parsedSchema && (
+                        <Card>
+                            <CardBody>
+                                <SchemaEditor
+                                    key={`schema-editor-output-${nodeID}`}
+                                    jsonValue={parsedSchema}
+                                    onChange={handleSchemaEditorChange}
+                                    options={jsonOptions}
+                                    nodeId={nodeID}
+                                    readOnly={readOnly}
+                                />
+                            </CardBody>
+                        </Card>
+                    )}
+                </Tab>
+                <Tab key="json" title="JSON Schema">
+                    <Card>
+                        <CardBody>
+                            <CodeEditor
+                                key={`code-editor-output-json-schema-${nodeID}`}
+                                code={schema || ''}
+                                mode="json"
+                                onChange={handleJsonEditorChange}
+                                readOnly={readOnly}
+                            />
+                        </CardBody>
+                    </Card>
+                </Tab>
+            </Tabs>
         </div>
     )
 }

--- a/frontend/src/components/nodes/nodeSidebar/OutputSchemaEditor.tsx
+++ b/frontend/src/components/nodes/nodeSidebar/OutputSchemaEditor.tsx
@@ -1,0 +1,180 @@
+import { Alert, Button, Card, CardBody, Tab, Tabs, Tooltip } from '@heroui/react'
+import { Icon } from '@iconify/react'
+import React from 'react'
+import { jsonOptions } from '../../../constants/jsonOptions'
+import CodeEditor from '../../CodeEditor'
+import SchemaEditor from './SchemaEditor'
+
+interface OutputSchemaEditorProps {
+    nodeID: string
+    currentNodeConfig: any
+    jsonSchemaError: string
+    handleInputChange: (key: string, value: any) => void
+    debouncedValidate: (value: string) => void
+    setCurrentNodeConfig: (updater: (prev: any) => any) => void
+    dispatch: any
+    updateNodeConfigOnly: any
+    generateJsonSchemaFromSchema: (schema: Record<string, string>) => string | null
+    extractSchemaFromJsonSchema: (jsonSchema: string) => { schema: Record<string, any> | null; error: string | null }
+    isLast?: boolean
+}
+
+const OutputSchemaEditor: React.FC<OutputSchemaEditorProps> = ({
+    nodeID,
+    currentNodeConfig,
+    jsonSchemaError,
+    handleInputChange,
+    debouncedValidate,
+    setCurrentNodeConfig,
+    dispatch,
+    updateNodeConfigOnly,
+    generateJsonSchemaFromSchema,
+    extractSchemaFromJsonSchema,
+    isLast = false,
+}) => {
+    const { schema: parsedSchema } = extractSchemaFromJsonSchema(currentNodeConfig.output_json_schema || '')
+
+    return (
+        <div key="output_json_schema">
+            <div className="flex items-center gap-2 mb-2">
+                <h3 className="font-semibold">Output Schema</h3>
+                <Tooltip
+                    content={
+                        currentNodeConfig?.has_fixed_output === true
+                            ? "This node has a fixed output schema that cannot be modified. The JSON schema provides detailed validation rules for the node's output."
+                            : currentNodeConfig?.llm_info?.model && currentNodeConfig?.llm_info?.supports_JSON_output
+                              ? "Define the structure of this node's output. You can use either the Simple Editor for basic types, or the JSON Schema Editor for more complex validation rules."
+                              : currentNodeConfig?.llm_info?.model && !currentNodeConfig?.llm_info?.supports_JSON_output
+                                ? "This model only supports a fixed output schema with a single 'output' field of type string. Schema editing is disabled."
+                                : "The output schema defines the structure of this node's output."
+                    }
+                    placement="left-start"
+                    showArrow={true}
+                    className="max-w-xs"
+                >
+                    <Icon icon="solar:question-circle-linear" className="text-default-400 cursor-help" width={20} />
+                </Tooltip>
+                {!currentNodeConfig?.has_fixed_output && currentNodeConfig?.llm_info?.model && (
+                    <Button
+                        isIconOnly
+                        radius="full"
+                        variant="light"
+                        size="sm"
+                        onClick={() => {
+                            const defaultSchema = {
+                                type: 'object',
+                                properties: {
+                                    output: { type: 'string' },
+                                },
+                                required: ['output'],
+                            }
+                            handleInputChange('output_json_schema', JSON.stringify(defaultSchema, null, 2))
+                        }}
+                    >
+                        <Icon icon="solar:restart-linear" width={20} />
+                    </Button>
+                )}
+            </div>
+            {currentNodeConfig?.has_fixed_output ? (
+                <div className="bg-default-100 rounded-lg p-4">
+                    <CodeEditor
+                        key={`code-editor-output-json-schema-${nodeID}`}
+                        code={currentNodeConfig.output_json_schema || ''}
+                        mode="json"
+                        onChange={() => {}} // No-op for fixed output nodes
+                        readOnly={true}
+                    />
+                    <p className="text-sm text-default-500 mt-2">
+                        This node has a fixed output schema that cannot be modified.
+                    </p>
+                </div>
+            ) : currentNodeConfig?.llm_info?.model ? (
+                <>
+                    {jsonSchemaError && (
+                        <Alert color="danger" className="mb-2">
+                            <div className="flex items-center gap-2">
+                                <span>{jsonSchemaError}</span>
+                            </div>
+                        </Alert>
+                    )}
+                    <Tabs aria-label="Schema Editor Options" disabledKeys={jsonSchemaError ? ['simple'] : []}>
+                        <Tab key="simple" title="Simple Editor">
+                            {parsedSchema && (
+                                <Card>
+                                    <CardBody>
+                                        <SchemaEditor
+                                            key={`schema-editor-output-${nodeID}`}
+                                            jsonValue={parsedSchema}
+                                            onChange={(newValue) => {
+                                                if (typeof newValue === 'object' && !('type' in newValue)) {
+                                                    const jsonSchema = generateJsonSchemaFromSchema(newValue)
+                                                    if (jsonSchema) {
+                                                        const updates = {
+                                                            output_json_schema: jsonSchema,
+                                                        }
+                                                        setCurrentNodeConfig((prev) => ({
+                                                            ...prev,
+                                                            ...updates,
+                                                        }))
+                                                        dispatch(
+                                                            updateNodeConfigOnly({
+                                                                id: nodeID,
+                                                                data: {
+                                                                    ...currentNodeConfig,
+                                                                    ...updates,
+                                                                },
+                                                            })
+                                                        )
+                                                    }
+                                                } else {
+                                                    const updates = {
+                                                        output_json_schema: JSON.stringify(newValue, null, 2),
+                                                    }
+                                                    setCurrentNodeConfig((prev) => ({
+                                                        ...prev,
+                                                        ...updates,
+                                                    }))
+                                                    dispatch(
+                                                        updateNodeConfigOnly({
+                                                            id: nodeID,
+                                                            data: {
+                                                                ...currentNodeConfig,
+                                                                ...updates,
+                                                            },
+                                                        })
+                                                    )
+                                                }
+                                            }}
+                                            options={jsonOptions}
+                                            nodeId={nodeID}
+                                        />
+                                    </CardBody>
+                                </Card>
+                            )}
+                        </Tab>
+                        <Tab key="json" title="JSON Schema">
+                            <Card>
+                                <CardBody>
+                                    <CodeEditor
+                                        key={`code-editor-output-json-schema-${nodeID}`}
+                                        code={currentNodeConfig.output_json_schema || ''}
+                                        mode="json"
+                                        onChange={(value: string) => {
+                                            handleInputChange('output_json_schema', value)
+                                            debouncedValidate(value)
+                                        }}
+                                    />
+                                </CardBody>
+                            </Card>
+                        </Tab>
+                    </Tabs>
+                </>
+            ) : (
+                <></>
+            )}
+            {!isLast && <hr className="my-2" />}
+        </div>
+    )
+}
+
+export default OutputSchemaEditor

--- a/frontend/src/components/nodes/nodeSidebar/SchemaEditor.tsx
+++ b/frontend/src/components/nodes/nodeSidebar/SchemaEditor.tsx
@@ -327,7 +327,13 @@ const SchemaField: React.FC<FieldProps> = ({ path, value, onUpdate, onDelete, re
                         )}
                     >
                         {availableFields.map((field) => (
-                            <SelectItem key={field} value={field}>
+                            <SelectItem
+                                key={field}
+                                value={field}
+                                classNames={{
+                                    title: 'w-full whitespace-normal break-words',
+                                }}
+                            >
                                 {field}
                             </SelectItem>
                         ))}
@@ -977,7 +983,13 @@ const SchemaEditor: React.FC<SchemaEditorProps> = ({
                         )}
                     >
                         {availableFields.map((field) => (
-                            <SelectItem key={field} value={field}>
+                            <SelectItem
+                                key={field}
+                                value={field}
+                                classNames={{
+                                    title: 'w-full whitespace-normal break-words',
+                                }}
+                            >
                                 {field}
                             </SelectItem>
                         ))}

--- a/frontend/src/store/flowSlice.ts
+++ b/frontend/src/store/flowSlice.ts
@@ -53,7 +53,7 @@ function rebuildRouterNodeSchema(state: FlowState, routerNode: FlowWorkflowNode)
                 const nodeTitle = sourceNodeConfig.title || sourceNode?.id
                 const sourceSchema = sourceNodeConfig.output_json_schema
 
-                properties[nodeTitle] = sourceSchema
+                properties[nodeTitle] = JSON.parse(sourceSchema)
             }
             return properties
         },

--- a/frontend/src/store/flowSlice.ts
+++ b/frontend/src/store/flowSlice.ts
@@ -319,22 +319,20 @@ const flowSlice = createSlice({
                 const sourceNodeConfig = sourceNode ? state.nodeConfigs[sourceNode.id] : undefined
 
                 // If target is a RouterNode and source has output schema, update target's schema
-                if (targetNode?.type === 'RouterNode' && sourceNodeConfig?.output_schema) {
-                    const sourceTitle = sourceNodeConfig.title || sourceNode?.id
-                    const currentSchema = { ...(targetNodeConfig?.output_schema || {}) }
+                if (targetNode?.type === 'RouterNode') {
+                    const sourceTitle = sourceNodeConfig.title
+                    const currentSchema = targetNodeConfig.output_json_schema || '{}'
 
-                    // Remove fields that start with this source's prefix
-                    const prefix = `${sourceTitle}.`
-                    Object.keys(currentSchema).forEach((key) => {
-                        if (key.startsWith(prefix)) {
-                            delete currentSchema[key]
-                        }
-                    })
+                    // Remove the property that corresponds to the source node's title
+                    let newSchema = JSON.parse(currentSchema)
+                    delete newSchema.properties[sourceTitle]
+                    newSchema['required'] = Object.keys(newSchema.properties)
+                    const updatedSchema = JSON.stringify(newSchema)
 
                     // Update the target node's schema
                     state.nodeConfigs[targetNode.id] = {
                         ...targetNodeConfig,
-                        output_schema: currentSchema,
+                        output_json_schema: updatedSchema,
                     }
                 }
 

--- a/frontend/src/store/flowSlice.ts
+++ b/frontend/src/store/flowSlice.ts
@@ -251,7 +251,7 @@ const flowSlice = createSlice({
             }
 
             // If output_schema changed, rebuild connected RouterNode/CoalesceNode schemas
-            if (data?.output_schema) {
+            if (data?.output_schema || data?.output_json_schema) {
                 const connectedRouterNodes = state.nodes.filter(
                     (targetNode) =>
                         targetNode.type === 'RouterNode' &&

--- a/frontend/src/types/api_types/nodeTypeSchemas.ts
+++ b/frontend/src/types/api_types/nodeTypeSchemas.ts
@@ -1,7 +1,7 @@
+import { RouteConditionGroup } from '@/types/api_types/routerSchemas'
 import { WorkflowNodeCoordinates } from '@/types/api_types/workflowSchemas'
 import { CoordinateExtent } from '@xyflow/react'
 import { ModelConstraints } from './modelMetadataSchemas'
-import { RouteConditionGroup } from '@/types/api_types/routerSchemas'
 
 export interface NodeTypeSchema {
     node_type_name: string
@@ -69,12 +69,15 @@ export interface FlowWorkflowNodeConfig {
     type?: string
     input_schema?: Record<string, any>
     output_schema?: Record<string, any>
+    output_json_schema?: string
     system_message?: string
     user_message?: string
-    few_shot_examples?: Array<{
-        input: string
-        output: string
-    }> | Record<string, any>[]
+    few_shot_examples?:
+        | Array<{
+              input: string
+              output: string
+          }>
+        | Record<string, any>[]
     llm_info?: {
         model?: string
         api_base?: string

--- a/frontend/src/utils/schemaUtils.ts
+++ b/frontend/src/utils/schemaUtils.ts
@@ -1,0 +1,79 @@
+/**
+ * Utility functions for handling JSON Schema operations
+ */
+
+/**
+ * Generates a JSON Schema from a simple schema object
+ * @param schema Record of field names to their types
+ * @returns JSON Schema string or null if invalid
+ */
+export const generateJsonSchemaFromSchema = (schema: Record<string, string>): string | null => {
+    if (!schema || Object.keys(schema).length === 0) return null
+
+    try {
+        const jsonSchema = {
+            type: 'object',
+            required: Object.keys(schema),
+            properties: {} as Record<string, { type: string }>,
+        }
+
+        for (const [key, type] of Object.entries(schema)) {
+            if (!key || !type) return null
+            jsonSchema.properties[key] = { type }
+        }
+
+        return JSON.stringify(jsonSchema, null, 2)
+    } catch (error) {
+        console.error('Error generating JSON schema:', error)
+        return null
+    }
+}
+
+/**
+ * Extracts a schema object from a JSON Schema string
+ * @param jsonSchema JSON Schema string to parse
+ * @returns Object containing the parsed schema and any error
+ */
+export const extractSchemaFromJsonSchema = (
+    jsonSchema: string
+): { schema: Record<string, any> | null; error: string | null } => {
+    if (!jsonSchema || !jsonSchema.trim()) {
+        return { schema: null, error: null }
+    }
+    try {
+        // Try to parse the schema
+        let parsed: Record<string, any>
+        try {
+            parsed = JSON.parse(jsonSchema.trim())
+        } catch (e: any) {
+            // If the schema has escaped characters, clean it up first
+            let cleaned = jsonSchema
+                .replace(/\"/g, '"') // Replace escaped quotes
+                .replace(/\\\[/g, '[') // Replace escaped brackets
+                .replace(/\\\]/g, ']')
+                .replace(/\\n/g, '') // Remove newlines
+                .replace(/\\t/g, '') // Remove tabs
+                .replace(/\\/g, '') // Remove remaining backslashes
+                .trim()
+            try {
+                parsed = JSON.parse(cleaned)
+            } catch (e: any) {
+                // Extract line and column info from the error message if available
+                const match = e.message.match(/at position (\d+)(?:\s*\(line (\d+) column (\d+)\))?/)
+                const errorMsg = match
+                    ? `Invalid JSON: ${e.message.split('at position')[0].trim()} at line ${match[2] || '?'}, column ${match[3] || '?'}`
+                    : `Invalid JSON: ${e.message}`
+                return { schema: null, error: errorMsg }
+            }
+        }
+
+        // If the parsed schema has a properties field (i.e. full JSON Schema format),
+        // return the nested properties so that nested objects are preserved.
+        if (parsed.properties) {
+            return { schema: parsed.properties, error: null }
+        }
+        return { schema: parsed, error: null }
+    } catch (error: any) {
+        return { schema: null, error: error.message || 'Invalid JSON Schema' }
+    }
+}


### PR DESCRIPTION
This pull request includes various changes to the backend and frontend components, focusing on handling node errors, improving schema parsing, and updating UI elements for better user experience. The most important changes are listed below:

### Backend Changes:
* [`backend/app/execution/workflow_executor.py`](diffhunk://#diff-8dd10b9c91f03781032cea965cb1788a2d49b9fb01a800ac09a2a7b6654ecd68R237-R241): Added handling for `CoalesceNode` to return `None` if all input values are `None`.

### Frontend Changes:
* `frontend/src/components/nodes/logic/CoalesceNode.tsx`: 
  - Imported `NodeErrorDisplay` and added `nodeError` state to display errors. [[1]](diffhunk://#diff-9e928b1ee9187bf15b19310bf1731bf5cba2fc9175d1524f53982ed3d7a17cceL1-L13) [[2]](diffhunk://#diff-9e928b1ee9187bf15b19310bf1731bf5cba2fc9175d1524f53982ed3d7a17cceR41)
  - Added error display component to the node's output section.
  - Updated class names for better UI consistency.

* `frontend/src/components/nodes/logic/RouterNode.tsx`:
  - Improved JSON schema parsing with error handling and extraction of properties.
  - Updated class names for better UI consistency. [[1]](diffhunk://#diff-32fa68bd81e295710ccf58fc52b31a15196088905646e9528815a09c75870cf8L514-R523) [[2]](diffhunk://#diff-32fa68bd81e295710ccf58fc52b31a15196088905646e9528815a09c75870cf8R543-R545) [[3]](diffhunk://#diff-32fa68bd81e295710ccf58fc52b31a15196088905646e9528815a09c75870cf8L573-R584) [[4]](diffhunk://#diff-32fa68bd81e295710ccf58fc52b31a15196088905646e9528815a09c75870cf8R603-R605)

* `frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx`:
  - Removed redundant imports and added new utility functions for schema handling. [[1]](diffhunk://#diff-bfbb4b8da1bcfb622620d5706176334f1a893d4dc5442ef0144bbf26e6162a26L8-L16) [[2]](diffhunk://#diff-bfbb4b8da1bcfb622620d5706176334f1a893d4dc5442ef0144bbf26e6162a26R43-R46) [[3]](diffhunk://#diff-bfbb4b8da1bcfb622620d5706176334f1a893d4dc5442ef0144bbf26e6162a26L83-L151)
  - Added read-only condition for output schema based on node type and model constraints. [[1]](diffhunk://#diff-bfbb4b8da1bcfb622620d5706176334f1a893d4dc5442ef0144bbf26e6162a26L694-R630) [[2]](diffhunk://#diff-bfbb4b8da1bcfb622620d5706176334f1a893d4dc5442ef0144bbf26e6162a26L706-R645)