### PR TITLE
Added support for gemini-2.0-flash in _model_info.py

### DIFF
--- a/backend/app/nodes/llm/_model_info.py
+++ b/backend/app/nodes/llm/_model_info.py
@@ -98,6 +98,7 @@ class LLMModels(str, Enum):
 
     # Google Models
     GEMINI_2_0_FLASH_EXP = "gemini/gemini-2.0-flash-exp"
+    GEMINI_2_0_FLASH = "gemini/gemini-2.0-flash"
     GEMINI_1_5_PRO = "gemini/gemini-1.5-pro"
     GEMINI_1_5_FLASH = "gemini/gemini-1.5-flash"
     GEMINI_1_5_PRO_LATEST = "gemini/gemini-1.5-pro-latest"
@@ -344,6 +345,23 @@ class LLMModels(str, Enum):
                 constraints=ModelConstraints(
                     max_tokens=8192, max_temperature=1.0
                 ).add_mime_categories(
+                    {
+                        MimeCategory.IMAGES,
+                        MimeCategory.AUDIO,
+                        MimeCategory.VIDEO,
+                        MimeCategory.DOCUMENTS,
+                        MimeCategory.TEXT,
+                    }
+                ),
+            ),
+            cls.GEMINI_2_0_FLASH.value: LLMModel(  
+                id=cls.GEMINI_2_0_FLASH.value,
+                provider=LLMProvider.GEMINI,
+                name="Gemini 2.0 Flash",  
+                constraints=ModelConstraints(
+                    max_tokens=8192,  
+                    max_temperature=2.0, 
+                ).add_mime_categories(  
                     {
                         MimeCategory.IMAGES,
                         MimeCategory.AUDIO,


### PR DESCRIPTION
Wanted to use this model but couldn't, so I coded it in. 

(This is my first pull request in general, so please by kind ;) Let me know if I can improve/do something differently)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Added support for `GEMINI_2_0_FLASH` model in `_model_info.py` with specific constraints and MIME categories.
> 
>   - **Behavior**:
>     - Added `GEMINI_2_0_FLASH` to `LLMModels` enum in `_model_info.py`.
>     - Updated `get_model_info()` to include `GEMINI_2_0_FLASH` with constraints: `max_tokens=8192`, `max_temperature=2.0`.
>     - Supports MIME categories: `IMAGES`, `AUDIO`, `VIDEO`, `DOCUMENTS`, `TEXT`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for 8bc7199f4470a3f9059f2bf63f36f072bb579ff4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->