### PR TITLE
Refactor: rendering of template variables inside NodeSideBar + add message variable to Slack node

### DIFF
--- a/backend/app/nodes/integrations/slack/slack_notify.py
+++ b/backend/app/nodes/integrations/slack/slack_notify.py
@@ -33,7 +33,6 @@ class SlackNotifyNodeConfig(BaseNodeConfig):
     message: str = Field(
         default="",
         description="The message template to send to Slack. Use {{variable}} syntax to include data from input nodes.",
-        json_schema_extra={"template": True},  # Mark this field as template-enabled
     )
     has_fixed_output: bool = True
     output_json_schema: str = Field(

--- a/backend/app/nodes/integrations/slack/slack_notify.py
+++ b/backend/app/nodes/integrations/slack/slack_notify.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel, Field
 from ...base import BaseNode, BaseNodeConfig, BaseNodeInput, BaseNodeOutput
 from ....integrations.slack.client import SlackClient
 from enum import Enum
+from jinja2 import Template
 
 
 class ModeEnum(str, Enum):
@@ -29,6 +30,11 @@ class SlackNotifyNodeConfig(BaseNodeConfig):
         ModeEnum.BOT,
         description="The mode to send the message in. Can be 'bot' or 'user'.",
     )
+    message: str = Field(
+        default="",
+        description="The message template to send to Slack. Use {{variable}} syntax to include data from input nodes.",
+        json_schema_extra={"template": True},  # Mark this field as template-enabled
+    )
     has_fixed_output: bool = True
     output_json_schema: str = Field(
         default=json.dumps(SlackNotifyNodeOutput.model_json_schema()),
@@ -50,9 +56,18 @@ class SlackNotifyNode(BaseNode):
         """
         Sends a message to the specified Slack channel.
         """
-
         # convert data to a string and send it to the Slack channel
-        message = json.dumps(input.model_dump())
+        if not self.config.message.strip():
+            # If no template is provided, dump the entire input as JSON
+            message = json.dumps(input.model_dump(), indent=2)
+        else:
+            # Render the message template with input variables
+            try:
+                message = Template(self.config.message).render(**input.model_dump())
+            except Exception as e:
+                print(f"[ERROR] Failed to render message template in {self.name}")
+                print(f"[ERROR] Template: {self.config.message} with input: {input.model_dump()}")
+                raise e
 
         client = SlackClient()
         ok, status = client.send_message(channel=self.config.channel, text=message, mode=self.config.mode)  # type: ignore

--- a/frontend/src/types/api_types/modelMetadataSchemas.ts
+++ b/frontend/src/types/api_types/modelMetadataSchemas.ts
@@ -2,11 +2,13 @@ export interface FieldMetadata {
     enum?: string[]
     default?: any
     title?: string
+    description?: string  // Field description from the backend
     minimum?: number
     maximum?: number
     type?: string
     required?: boolean
     properties?: Record<string, FieldMetadata>
+    template?: boolean  // Flag to indicate if this field supports template variables
 }
 
 export interface ModelConstraints {


### PR DESCRIPTION
This pull request refactors the NodeSideBar and adds a message variable to the Slack integration

### Backend Enhancements:
* [`backend/app/nodes/integrations/slack/slack_notify.py`](diffhunk://#diff-e93542c57f1ad48a608661a73812d83fc7fc2e837a2d2993506dd2b83d9b648dR6): Added support for Jinja2 templates to render Slack messages dynamically based on input variables. Added a new `message` field to `SlackNotifyNodeConfig` for specifying the template. Updated the `run` method to render the message template or fallback to JSON if no template is provided. [[1]](diffhunk://#diff-e93542c57f1ad48a608661a73812d83fc7fc2e837a2d2993506dd2b83d9b648dR6) [[2]](diffhunk://#diff-e93542c57f1ad48a608661a73812d83fc7fc2e837a2d2993506dd2b83d9b648dR33-R36) [[3]](diffhunk://#diff-e93542c57f1ad48a608661a73812d83fc7fc2e837a2d2993506dd2b83d9b648dL53-R69)

### Frontend Enhancements:
* [`frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx`](diffhunk://#diff-bfbb4b8da1bcfb622620d5706176334f1a893d4dc5442ef0144bbf26e6162a26R194-R211): Added a helper function `isTemplateField` to identify template fields based on metadata and known patterns. Improved the rendering logic for fields, including special handling for template fields, code editor fields, and input/output maps. [[1]](diffhunk://#diff-bfbb4b8da1bcfb622620d5706176334f1a893d4dc5442ef0144bbf26e6162a26R194-R211) [[2]](diffhunk://#diff-bfbb4b8da1bcfb622620d5706176334f1a893d4dc5442ef0144bbf26e6162a26R549-R554) [[3]](diffhunk://#diff-bfbb4b8da1bcfb622620d5706176334f1a893d4dc5442ef0144bbf26e6162a26L636) [[4]](diffhunk://#diff-bfbb4b8da1bcfb622620d5706176334f1a893d4dc5442ef0144bbf26e6162a26L714-R778) [[5]](diffhunk://#diff-bfbb4b8da1bcfb622620d5706176334f1a893d4dc5442ef0144bbf26e6162a26L762-R789) [[6]](diffhunk://#diff-bfbb4b8da1bcfb622620d5706176334f1a893d4dc5442ef0144bbf26e6162a26R799-L844)
* [`frontend/src/types/api_types/modelMetadataSchemas.ts`](diffhunk://#diff-201e26f520911e12c0f78c6bfdb80161b8e685f34b17134b71b8be4cc619368eR5-R11): Enhanced the `FieldMetadata` interface to include a `description` field and a `template` flag to indicate if a field supports template variables.