### PR TITLE
Fix/partial run

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -24,7 +24,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { useSaveWorkflow } from '../hooks/useSaveWorkflow'
 import { useWorkflowExecution } from '../hooks/useWorkflowExecution'
 import { useWorkflowFileOperations } from '../hooks/useWorkflowFileOperations'
-import { setProjectName } from '../store/flowSlice'
+import { setProjectName, setRunModalOpen } from '../store/flowSlice'
 import { RootState } from '../store/store'
 import { AlertState } from '../types/alert'
 import { getRunStatus, getWorkflow } from '../utils/api'
@@ -58,6 +58,7 @@ const Header: React.FC<HeaderProps> = ({ activePage, associatedWorkflowId, runId
     const testInputs = useSelector((state: RootState) => state.flow.testInputs)
     const selectedTestInputId = useSelector((state: RootState) => state.flow.selectedTestInputId)
     const [isHelpModalOpen, setIsHelpModalOpen] = useState<boolean>(false)
+    const isRunModalOpen = useSelector((state: RootState) => state.flow.isRunModalOpen)
 
     const router = useRouter()
     const { id } = router.query
@@ -84,7 +85,7 @@ const Header: React.FC<HeaderProps> = ({ activePage, associatedWorkflowId, runId
         useWorkflowFileOperations({ showAlert })
 
     const handleRunWorkflow = async (): Promise<void> => {
-        setIsDebugModalOpen(true)
+        dispatch(setRunModalOpen(true))
     }
 
     const handleProjectNameChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
@@ -535,11 +536,11 @@ const Header: React.FC<HeaderProps> = ({ activePage, associatedWorkflowId, runId
                 </NavbarContent>
             </Navbar>
             <RunModal
-                isOpen={isDebugModalOpen}
-                onOpenChange={setIsDebugModalOpen}
+                isOpen={isRunModalOpen}
+                onOpenChange={(isOpen) => dispatch(setRunModalOpen(isOpen))}
                 onRun={async (selectedInputs) => {
                     await executeWorkflow(selectedInputs)
-                    setIsDebugModalOpen(false)
+                    dispatch(setRunModalOpen(false))
                 }}
             />
             <DeployModal

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -23,17 +23,16 @@ import { useHotkeys } from 'react-hotkeys-hook'
 import { useDispatch, useSelector } from 'react-redux'
 import { useSaveWorkflow } from '../hooks/useSaveWorkflow'
 import { useWorkflowExecution } from '../hooks/useWorkflowExecution'
+import { useWorkflowFileOperations } from '../hooks/useWorkflowFileOperations'
 import { setProjectName } from '../store/flowSlice'
+import { RootState } from '../store/store'
 import { AlertState } from '../types/alert'
 import { getRunStatus, getWorkflow } from '../utils/api'
+import ConfirmationModal from './modals/ConfirmationModal'
 import DeployModal from './modals/DeployModal'
 import HelpModal from './modals/HelpModal'
 import RunModal from './modals/RunModal'
 import SettingsCard from './modals/SettingsModal'
-import { initializeFlow } from '../store/flowSlice'
-import { RootState } from '../store/store'
-import { useWorkflowFileOperations } from '../hooks/useWorkflowFileOperations'
-import ConfirmationModal from './modals/ConfirmationModal'
 
 interface HeaderProps {
     activePage: 'dashboard' | 'workflow' | 'evals' | 'trace' | 'rag'
@@ -57,7 +56,7 @@ const Header: React.FC<HeaderProps> = ({ activePage, associatedWorkflowId, runId
         isVisible: false,
     })
     const testInputs = useSelector((state: RootState) => state.flow.testInputs)
-    const [selectedRow, setSelectedRow] = useState<string | null>(null)
+    const selectedTestInputId = useSelector((state: RootState) => state.flow.selectedTestInputId)
     const [isHelpModalOpen, setIsHelpModalOpen] = useState<boolean>(false)
 
     const router = useRouter()
@@ -81,19 +80,8 @@ const Header: React.FC<HeaderProps> = ({ activePage, associatedWorkflowId, runId
 
     const saveWorkflow = useSaveWorkflow()
 
-    const {
-        handleFileUpload,
-        isConfirmationOpen,
-        setIsConfirmationOpen,
-        handleConfirmOverwrite,
-        pendingWorkflowData
-    } = useWorkflowFileOperations({ showAlert })
-
-    useEffect(() => {
-        if (testInputs.length > 0 && !selectedRow) {
-            setSelectedRow(testInputs[0].id.toString())
-        }
-    }, [testInputs])
+    const { handleFileUpload, isConfirmationOpen, setIsConfirmationOpen, handleConfirmOverwrite, pendingWorkflowData } =
+        useWorkflowFileOperations({ showAlert })
 
     const handleRunWorkflow = async (): Promise<void> => {
         setIsDebugModalOpen(true)
@@ -155,7 +143,7 @@ const Header: React.FC<HeaderProps> = ({ activePage, associatedWorkflowId, runId
                 return
             }
 
-            const testCase = testInputs.find((row) => row.id.toString() === selectedRow) ?? testInputs[0]
+            const testCase = testInputs.find((row) => row.id.toString() === selectedTestInputId) ?? testInputs[0]
 
             if (testCase) {
                 const { id, ...inputValues } = testCase
@@ -465,12 +453,7 @@ const Header: React.FC<HeaderProps> = ({ activePage, associatedWorkflowId, runId
                         </NavbarItem>
                         <NavbarItem className="hidden sm:flex">
                             <Tooltip content="Upload Workflow JSON">
-                                <Button
-                                    isIconOnly
-                                    radius="full"
-                                    variant="light"
-                                    onPress={handleFileUpload}
-                                >
+                                <Button isIconOnly radius="full" variant="light" onPress={handleFileUpload}>
                                     <Icon className="text-foreground/60" icon="solar:upload-linear" width={24} />
                                 </Button>
                             </Tooltip>
@@ -558,14 +541,12 @@ const Header: React.FC<HeaderProps> = ({ activePage, associatedWorkflowId, runId
                     await executeWorkflow(selectedInputs)
                     setIsDebugModalOpen(false)
                 }}
-                selectedRow={selectedRow}
-                onSelectedRowChange={setSelectedRow}
             />
             <DeployModal
                 isOpen={isDeployModalOpen}
                 onOpenChange={setIsDeployModalOpen}
                 workflowId={workflowId}
-                testInput={testInputs.find((row) => row.id.toString() === selectedRow) ?? testInputs[0]}
+                testInput={testInputs.find((row) => row.id.toString() === selectedTestInputId) ?? testInputs[0]}
             />
             <HelpModal isOpen={isHelpModalOpen} onClose={() => setIsHelpModalOpen(false)} />
         </>

--- a/frontend/src/hooks/usePartialRun.ts
+++ b/frontend/src/hooks/usePartialRun.ts
@@ -1,4 +1,4 @@
-import { updateNodeDataOnly, updateNodesFromPartialRun } from '@/store/flowSlice'
+import { setRunModalOpen, updateNodeDataOnly, updateNodesFromPartialRun } from '@/store/flowSlice'
 import { AppDispatch, RootState } from '@/store/store'
 import { useState } from 'react'
 import { useSelector } from 'react-redux'
@@ -44,7 +44,7 @@ const usePartialRun = (dispatch: AppDispatch) => {
         try {
             // If no initialInputs provided, use the selected test input
             let effectiveInitialInputs = initialInputs
-            if (!effectiveInitialInputs) {
+            if (!effectiveInitialInputs && testInputs.length > 0) {
                 const testCase = testInputs.find((row) => row.id.toString() === selectedTestInputId) ?? testInputs[0]
                 if (testCase) {
                     const { id, ...inputValues } = testCase
@@ -55,6 +55,12 @@ const usePartialRun = (dispatch: AppDispatch) => {
                         }
                     }
                 }
+            }
+
+            // If no effectiveInitialInputs and no test inputs, open the RunModal
+            if (!effectiveInitialInputs && testInputs.length === 0) {
+                dispatch(setRunModalOpen(true))
+                return
             }
 
             const data = await runPartialWorkflow(

--- a/frontend/src/store/flowSlice.ts
+++ b/frontend/src/store/flowSlice.ts
@@ -28,6 +28,7 @@ const initialState: FlowState = {
     workflowInputVariables: {},
     testInputs: [],
     inputNodeValues: {},
+    selectedTestInputId: null,
     history: {
         past: [],
         future: [],
@@ -45,10 +46,8 @@ const saveToHistory = (state: FlowState) => {
 const generateJsonSchema = (schema: Record<string, any>): string => {
     const jsonSchema = {
         type: 'object',
-        properties: Object.fromEntries(
-            Object.entries(schema).map(([key, type]) => [key, { type }])
-        ),
-        required: Object.keys(schema)
+        properties: Object.fromEntries(Object.entries(schema).map(([key, type]) => [key, { type }])),
+        required: Object.keys(schema),
     }
     return JSON.stringify(jsonSchema, null, 2)
 }
@@ -247,25 +246,25 @@ const flowSlice = createSlice({
 
         updateNodeConfigOnly: (state, action: PayloadAction<{ id: string; data: any }>) => {
             const { id, data } = action.payload
-            const currentConfig = state.nodeConfigs[id] || {};
+            const currentConfig = state.nodeConfigs[id] || {}
             if (data.few_shot_examples) {
-                const oldExamples = currentConfig.few_shot_examples || [];
-                const newExamples = data.few_shot_examples;
-                const maxLength = Math.max(oldExamples.length, newExamples.length);
-                const mergedExamples = [];
+                const oldExamples = currentConfig.few_shot_examples || []
+                const newExamples = data.few_shot_examples
+                const maxLength = Math.max(oldExamples.length, newExamples.length)
+                const mergedExamples = []
                 for (let i = 0; i < maxLength; i++) {
-                    mergedExamples[i] = { ...(oldExamples[i] || {}), ...(newExamples[i] || {}) };
+                    mergedExamples[i] = { ...(oldExamples[i] || {}), ...(newExamples[i] || {}) }
                 }
                 state.nodeConfigs[id] = {
                     ...currentConfig,
                     ...data,
-                    few_shot_examples: mergedExamples
-                };
+                    few_shot_examples: mergedExamples,
+                }
             } else {
                 state.nodeConfigs[id] = {
                     ...currentConfig,
                     ...data,
-                };
+                }
             }
 
             // If output_schema changed, rebuild connected RouterNode/CoalesceNode schemas
@@ -753,6 +752,10 @@ const flowSlice = createSlice({
                 return node // Return unchanged node if no output found
             })
         },
+
+        setSelectedTestInputId: (state, action: PayloadAction<string | null>) => {
+            state.selectedTestInputId = action.payload
+        },
     },
 })
 
@@ -791,6 +794,7 @@ export const {
     addNodeWithConfig,
     updateNodeParentAndCoordinates,
     updateNodesFromPartialRun,
+    setSelectedTestInputId,
 } = flowSlice.actions
 
 export default flowSlice.reducer

--- a/frontend/src/store/flowSlice.ts
+++ b/frontend/src/store/flowSlice.ts
@@ -33,6 +33,7 @@ const initialState: FlowState = {
         past: [],
         future: [],
     },
+    isRunModalOpen: false,
 }
 
 const saveToHistory = (state: FlowState) => {
@@ -756,6 +757,10 @@ const flowSlice = createSlice({
         setSelectedTestInputId: (state, action: PayloadAction<string | null>) => {
             state.selectedTestInputId = action.payload
         },
+
+        setRunModalOpen: (state, action: PayloadAction<boolean>) => {
+            state.isRunModalOpen = action.payload
+        },
     },
 })
 
@@ -795,6 +800,7 @@ export const {
     updateNodeParentAndCoordinates,
     updateNodesFromPartialRun,
     setSelectedTestInputId,
+    setRunModalOpen,
 } = flowSlice.actions
 
 export default flowSlice.reducer

--- a/frontend/src/types/api_types/flowStateSchema.ts
+++ b/frontend/src/types/api_types/flowStateSchema.ts
@@ -1,6 +1,10 @@
-import { NodeTypes, FlowWorkflowNode, FlowWorkflowEdge, FlowWorkflowNodeConfig } from '@/types/api_types/nodeTypeSchemas';
-import { TestInput } from '@/types/api_types/workflowSchemas';
-
+import {
+    FlowWorkflowEdge,
+    FlowWorkflowNode,
+    FlowWorkflowNodeConfig,
+    NodeTypes,
+} from '@/types/api_types/nodeTypeSchemas'
+import { TestInput } from '@/types/api_types/workflowSchemas'
 
 export interface FlowState {
     nodeTypes: NodeTypes
@@ -15,8 +19,9 @@ export interface FlowState {
     workflowInputVariables: Record<string, any>
     testInputs: TestInput[]
     inputNodeValues: Record<string, any>
+    selectedTestInputId: string | null
     history: {
-        past: Array<{ nodes: FlowWorkflowNode[]; edges: FlowWorkflowEdge[]} >
-        future: Array<{ nodes: FlowWorkflowNode[]; edges: FlowWorkflowEdge[]} >
+        past: Array<{ nodes: FlowWorkflowNode[]; edges: FlowWorkflowEdge[] }>
+        future: Array<{ nodes: FlowWorkflowNode[]; edges: FlowWorkflowEdge[] }>
     }
 }

--- a/frontend/src/types/api_types/flowStateSchema.ts
+++ b/frontend/src/types/api_types/flowStateSchema.ts
@@ -24,4 +24,5 @@ export interface FlowState {
         past: Array<{ nodes: FlowWorkflowNode[]; edges: FlowWorkflowEdge[] }>
         future: Array<{ nodes: FlowWorkflowNode[]; edges: FlowWorkflowEdge[] }>
     }
+    isRunModalOpen: boolean
 }


### PR DESCRIPTION
This pull request includes significant updates to the `Header` and `RunModal` components in the frontend, with a focus on state management improvements and code simplification. The most important changes include the introduction of new state variables for managing the selected test input and the run modal's open state, as well as the refactoring of related components and hooks to use these new state variables.

### State Management Improvements:
* Added `selectedTestInputId` and `isRunModalOpen` state variables to the `flowSlice` to manage the selected test input and the run modal's open state (`frontend/src/store/flowSlice.ts`) [[1]](diffhunk://#diff-a05e8f2a3b2bba62482cce12a7006c846f37c7598dd95501a8a36e65cdb4a866R31-R36) [[2]](diffhunk://#diff-a05e8f2a3b2bba62482cce12a7006c846f37c7598dd95501a8a36e65cdb4a866R756-R763).

### Component Updates:
* Updated `Header` component to use the new `selectedTestInputId` and `isRunModalOpen` state variables, replacing local state variables and simplifying modal handling (`frontend/src/components/Header.tsx`) [[1]](diffhunk://#diff-c510609aa826d49ad460d88069bb38a03f4369437f399594f14aa6019327c9cdL26-L36) [[2]](diffhunk://#diff-c510609aa826d49ad460d88069bb38a03f4369437f399594f14aa6019327c9cdL60-R61) [[3]](diffhunk://#diff-c510609aa826d49ad460d88069bb38a03f4369437f399594f14aa6019327c9cdL84-R88) [[4]](diffhunk://#diff-c510609aa826d49ad460d88069bb38a03f4369437f399594f14aa6019327c9cdL158-R147) [[5]](diffhunk://#diff-c510609aa826d49ad460d88069bb38a03f4369437f399594f14aa6019327c9cdL468-R457) [[6]](diffhunk://#diff-c510609aa826d49ad460d88069bb38a03f4369437f399594f14aa6019327c9cdL555-R550).
* Refactored `RunModal` component to remove `selectedRow` state and use `selectedTestInputId` from the global state instead (`frontend/src/components/modals/RunModal.tsx`) [[1]](diffhunk://#diff-ab4ae89c478edfe7f7e7759ff63b7f1d6d3b13553348be9485c23696ddf8cad6L25-R25) [[2]](diffhunk://#diff-ab4ae89c478edfe7f7e7759ff63b7f1d6d3b13553348be9485c23696ddf8cad6L36-R48) [[3]](diffhunk://#diff-ab4ae89c478edfe7f7e7759ff63b7f1d6d3b13553348be9485c23696ddf8cad6L72) [[4]](diffhunk://#diff-ab4ae89c478edfe7f7e7759ff63b7f1d6d3b13553348be9485c23696ddf8cad6L87-R82) [[5]](diffhunk://#diff-ab4ae89c478edfe7f7e7759ff63b7f1d6d3b13553348be9485c23696ddf8cad6L117-R109) [[6]](diffhunk://#diff-ab4ae89c478edfe7f7e7759ff63b7f1d6d3b13553348be9485c23696ddf8cad6L281-R271) [[7]](diffhunk://#diff-ab4ae89c478edfe7f7e7759ff63b7f1d6d3b13553348be9485c23696ddf8cad6L311-R297) [[8]](diffhunk://#diff-ab4ae89c478edfe7f7e7759ff63b7f1d6d3b13553348be9485c23696ddf8cad6L356-R345) [[9]](diffhunk://#diff-ab4ae89c478edfe7f7e7759ff63b7f1d6d3b13553348be9485c23696ddf8cad6L528-R515).

### Hook Updates:
* Modified `usePartialRun` hook to leverage the new `selectedTestInputId` state and handle the case where no initial inputs are provided by opening the run modal (`frontend/src/hooks/usePartialRun.ts`) [[1]](diffhunk://#diff-2a14ad86ba3665215ce52d22d9d9ac4544ad5b2b0cd53a395d6844a2fb2a53b2R1-L4) [[2]](diffhunk://#diff-2a14ad86ba3665215ce52d22d9d9ac4544ad5b2b0cd53a395d6844a2fb2a53b2L20-R21) [[3]](diffhunk://#diff-2a14ad86ba3665215ce52d22d9d9ac4544ad5b2b0cd53a395d6844a2fb2a53b2R30-R32) [[4]](diffhunk://#diff-2a14ad86ba3665215ce52d22d9d9ac4544ad5b2b0cd53a395d6844a2fb2a53b2L41-R72).

These changes collectively enhance the maintainability and readability of the codebase by centralizing state management and reducing redundancy.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improve state management in `Header` and `RunModal` by introducing global state variables for selected test input and run modal state.
> 
>   - **State Management**:
>     - Add `selectedTestInputId` and `isRunModalOpen` to `flowSlice` for managing selected test input and run modal state.
>   - **Component Updates**:
>     - Update `Header` to use `selectedTestInputId` and `isRunModalOpen`, replacing local state variables.
>     - Refactor `RunModal` to remove `selectedRow` state, using `selectedTestInputId` from global state.
>   - **Hook Updates**:
>     - Modify `usePartialRun` to use `selectedTestInputId` and handle no initial inputs by opening run modal.
>   - **Misc**:
>     - Add `setSelectedTestInputId` and `setRunModalOpen` actions in `flowSlice`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for 748dbe27510cf43b36e3f88d9d5f747c6fb6e3c1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->