### PR TITLE
feat: improve page titles. show workflow title when available

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -134,6 +134,21 @@ const Header: React.FC<HeaderProps> = ({ activePage, associatedWorkflowId, runId
         }
     }, [isHistoryOpen])
 
+    useEffect(() => {
+        if (activePage === 'workflow' || activePage === 'trace') {
+            document.title = `${projectName} - PySpur`
+        }
+        if (activePage === 'dashboard') {
+            document.title = `Dashboard - PySpur`
+        }
+        if (activePage === 'evals') {
+            document.title = `Evals - PySpur`
+        }
+        if (activePage === 'rag') {
+            document.title = `RAG - PySpur`
+        }
+    }, [projectName, activePage])
+
     useHotkeys(
         ['mod+enter'],
         (e) => {


### PR DESCRIPTION
This pull request includes a change to the `Header` component in the `frontend/src/components/Header.tsx` file. The change involves updating the document title based on the active page.

* [`frontend/src/components/Header.tsx`](diffhunk://#diff-c510609aa826d49ad460d88069bb38a03f4369437f399594f14aa6019327c9cdR137-R151): Added a `useEffect` hook to dynamically update the document title depending on the value of `activePage`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates document title in `Header.tsx` based on `activePage` using `useEffect`.
> 
>   - **Behavior**:
>     - Updates document title in `Header.tsx` using `useEffect` based on `activePage`.
>     - Handles `activePage` values: 'workflow', 'trace', 'dashboard', 'evals', 'rag'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for d494aaa9607a48f9ecbc5c86ca98e46b8d285322. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->