### PR TITLE
Update start_pyspur_docker.sh

### DIFF
--- a/start_pyspur_docker.sh
+++ b/start_pyspur_docker.sh
@@ -71,7 +71,7 @@ cp .env.example .env
 
 # Start the services
 print_message "Launching PySpur services..." "$GREEN"
-if docker compose up -d; then
+if docker-compose up -d; then
     print_message "\n🎉 PySpur is now running!" "$GREEN"
     print_message "\nProject created in: $(pwd)" "$GREEN"
     print_message "Access PySpur at: http://localhost:6080" "$GREEN"


### PR DESCRIPTION
It seems that the command "docker compose up -d" in script missing a symbol '-'.

![1740368556881](https://github.com/user-attachments/assets/06cd7bce-df1d-4edf-8e2d-37f3439c036e)

after 
![17403693654820](https://github.com/user-attachments/assets/b5bda2ab-eb31-41d3-86ac-8c94510a47e4)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `docker compose` command to `docker-compose` in `start_pyspur_docker.sh`.
> 
>   - **Bug Fix**:
>     - Corrects `docker compose up -d` to `docker-compose up -d` in `start_pyspur_docker.sh` to ensure proper execution of Docker services.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for 27812b2ab5bc660a9811ea7bff366040ac42c739. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->