### PR TITLE
fixing bugs with the ollama/deepseek-r1 integration

### DIFF
--- a/backend/pyspur/nodes/llm/_model_info.py
+++ b/backend/pyspur/nodes/llm/_model_info.py
@@ -27,6 +27,8 @@ class ModelConstraints(BaseModel):
     supports_max_tokens: bool = True
     supports_temperature: bool = True
     supported_mime_types: Set[RecognisedMimeType] = set()  # Empty set means no multimodal support
+    supports_reasoning: bool = False
+    reasoning_separator: str = r'<think>.*?</think>'
 
     def add_mime_categories(self, categories: Set[MimeCategory]) -> "ModelConstraints":
         """Add MIME type support for entire categories.
@@ -468,6 +470,7 @@ class LLMModels(str, Enum):
                     max_temperature=2.0,
                     supports_JSON_output=False,
                     supports_max_tokens=False,
+                    supports_reasoning=True
                 )
             ),
             cls.OLLAMA_MISTRAL_SMALL.value: LLMModel(

--- a/backend/pyspur/nodes/llm/_model_info.py
+++ b/backend/pyspur/nodes/llm/_model_info.py
@@ -463,7 +463,12 @@ class LLMModels(str, Enum):
                 id=cls.OLLAMA_DEEPSEEK_R1.value,
                 provider=LLMProvider.OLLAMA,
                 name="Deepseek R1",
-                constraints=ModelConstraints(max_tokens=4096, max_temperature=2.0),
+                constraints=ModelConstraints(
+                    max_tokens=8192,
+                    max_temperature=2.0,
+                    supports_JSON_output=False,
+                    supports_max_tokens=False,
+                )
             ),
             cls.OLLAMA_MISTRAL_SMALL.value: LLMModel(
                 id=cls.OLLAMA_MISTRAL_SMALL.value,

--- a/backend/pyspur/nodes/llm/_utils.py
+++ b/backend/pyspur/nodes/llm/_utils.py
@@ -386,6 +386,10 @@ async def generate_text(
     # For models that don't support JSON output, wrap the response in a JSON structure
     if not supports_json:
         sanitized_response = response.replace('"', '\\"').replace("\n", "\\n")
+        if model_info and model_info.constraints.supports_reasoning:
+            separator = model_info.constraints.reasoning_separator
+            sanitized_response = re.sub(separator, '', sanitized_response)
+
         # Check for provider-specific fields
         if hasattr(raw_response, "choices") and len(raw_response.choices) > 0:
             if hasattr(raw_response.choices[0].message, "provider_specific_fields"):

--- a/backend/pyspur/nodes/llm/_utils.py
+++ b/backend/pyspur/nodes/llm/_utils.py
@@ -376,6 +376,10 @@ async def generate_text(
             raw_response = await completion_with_backoff(**kwargs)
             response = raw_response
     else:
+        if model_name.startswith("ollama"):
+            if api_base is None:
+                api_base = os.getenv("OLLAMA_BASE_URL")
+            kwargs['api_base'] = api_base
         raw_response = await completion_with_backoff(**kwargs)
         response = raw_response
 

--- a/backend/pyspur/nodes/llm/_utils.py
+++ b/backend/pyspur/nodes/llm/_utils.py
@@ -388,7 +388,7 @@ async def generate_text(
         sanitized_response = response.replace('"', '\\"').replace("\n", "\\n")
         if model_info and model_info.constraints.supports_reasoning:
             separator = model_info.constraints.reasoning_separator
-            sanitized_response = re.sub(separator, '', sanitized_response)
+            sanitized_response = re.sub(separator, '', sanitized_response, flags=re.DOTALL)
 
         # Check for provider-specific fields
         if hasattr(raw_response, "choices") and len(raw_response.choices) > 0:


### PR DESCRIPTION
DeepSeek-R1 doesn't properly support JSON and for some prompts, it returns strange results. This is an attempt to fix that.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves `ollama/deepseek-r1` integration by updating model constraints and refining JSON and reasoning response handling.
> 
>   - **Model Constraints**:
>     - In `_model_info.py`, added `supports_reasoning` and `reasoning_separator` to `ModelConstraints`.
>     - Updated `OLLAMA_DEEPSEEK_R1` constraints to `max_tokens=8192`, `supports_JSON_output=False`, `supports_max_tokens=False`, and `supports_reasoning=True`.
>   - **Response Handling**:
>     - In `_utils.py`, `generate_text()` now removes reasoning separators from responses if `supports_reasoning` is true.
>     - Adjusted `generate_text()` to set `api_base` for `ollama` models if not provided.
>   - **Misc**:
>     - Minor adjustments to JSON response handling in `generate_text()` for models not supporting JSON output.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for e9f11c2b688a5286db692cd0e445c0eeab0f0a03. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->