### PR TITLE
Replace custom HTML with a JSON view

### DIFF
--- a/frontend/src/components/nodes/NodeOutputDisplay.tsx
+++ b/frontend/src/components/nodes/NodeOutputDisplay.tsx
@@ -4,6 +4,9 @@ import SyntaxHighlighter from 'react-syntax-highlighter/dist/cjs/prism'
 import { oneDark } from 'react-syntax-highlighter/dist/cjs/styles/prism'
 import { Icon } from '@iconify/react'
 
+import JsonView from 'react18-json-view'
+import 'react18-json-view/src/style.css'
+
 interface NodeOutputDisplayProps {
     output: Record<string, any>
 }
@@ -143,31 +146,7 @@ const NodeOutputDisplay: React.FC<NodeOutputDisplayProps> = ({ output }) => {
     const renderJsonObject = (obj: Record<string, any>) => {
         return (
             <div style={{ width: '100%' }}>
-                {Object.entries(obj).map(([key, val]) => (
-                    <div
-                        key={key}
-                        className="group mb-2 ml-2 border-l-2 border-gray-200 dark:border-gray-700/50 pl-2"
-                    >
-                        <div className="text-lg font-semibold mb-1">{key}:</div>
-                        <div className="ml-2">{renderValue(val)}</div>
-                        <div className="flex justify-end mt-3">
-                            <button
-                                onClick={(e) => {
-                                    e.stopPropagation();
-                                    copyToClipboard(val, key);
-                                }}
-                                className="px-3 py-1.5 rounded-md bg-white/10 dark:bg-gray-800/50 hover:bg-gray-100 dark:hover:bg-gray-700/50 transition-all flex items-center gap-2 border border-gray-200 dark:border-gray-700/50 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200"
-                                title="Copy to clipboard"
-                            >
-                                <Icon
-                                    icon={copiedKey === key ? 'solar:check-circle-bold' : 'solar:copy-linear'}
-                                    className={copiedKey === key ? 'text-green-500 dark:text-green-400' : 'text-gray-500 dark:text-gray-400'}
-                                    width={16}
-                                />
-                            </button>
-                        </div>
-                    </div>
-                ))}
+                <JsonView src={obj} />
             </div>
         )
     }


### PR DESCRIPTION
In one of my nodes, there's a huge amount of JSON formatted data returned by an API (about 600KB of data, including several base64 encoded images). Along with all of the other nodes in my spur, this causes the entire frontend to be extremely slow, or even freeze, after the workflow is run and all the outputs are rendered.

After replacing with this JSONView, the performance is far better. 

I don't have any benchmarks or anything for this, so feel free to reject it. I just thought it might be useful in general.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces custom HTML with `JsonView` in `NodeOutputDisplay.tsx` to improve performance for large JSON data.
> 
>   - **Behavior**:
>     - Replaces custom HTML rendering with `JsonView` in `NodeOutputDisplay.tsx` for JSON data.
>     - Improves performance for large JSON data sets, such as those with base64 images.
>   - **Imports**:
>     - Adds `JsonView` and its CSS from `react18-json-view`.
>   - **Misc**:
>     - Removes custom HTML and button logic for JSON rendering in `renderJsonObject()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for 72d3550ce8500f8b46ee3360036ebe2996dc6930. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->