### PR TITLE
Remove husky prepare script from package.json

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -80,8 +80,7 @@
         "start": "next start",
         "lint": "next lint",
         "format": "prettier --write .",
-        "lint-fix": "next lint --fix",
-        "prepare": "husky install"
+        "lint-fix": "next lint --fix"
     },
     "eslintConfig": {
         "extends": [


### PR DESCRIPTION
Eliminate the prepare script for husky installation in package.json to streamline the setup process.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `prepare` script for Husky installation from `package.json`.
> 
>   - **Scripts**:
>     - Remove `prepare` script from `scripts` in `package.json`, which was used for Husky installation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for abb972f65c71f86976330d88054bc40305f88a0a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->