### PR TITLE
fix: base node composite inputs

### DIFF
--- a/frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx
+++ b/frontend/src/components/nodes/nodeSidebar/NodeSidebar.tsx
@@ -1168,7 +1168,7 @@ const NodeSidebar: React.FC<NodeSidebarProps> = ({ nodeID, readOnly }) => {
         // Prioritize system_message, user_message, and template fields to appear first
         const priorityFields = ['system_message', 'user_message']
         const templateFields = keys
-            .filter((key) => key.includes('template') || key.includes('message') || key.includes('prompt'))
+            .filter((key) => (key.includes('template') || key.includes('message') || key.includes('prompt')) && key !== 'enable_message_history' && key !== 'message_history_variable')
             .filter((key) => !priorityFields.includes(key))
 
         // Filter out thinking-related fields if not using Claude 3.7 Sonnet


### PR DESCRIPTION
It turns out that our composite input creation logic was previously reassigning keys based on each value’s class name rather than preserving the original node IDs. Because of that, when the SingleLLMCallNode template looks for "RetrieverNode_1", the data isn’t available (resulting in a Jinja2 UndefinedError).

This pull request includes changes to the `backend/pyspur/nodes/base.py` file to improve the handling of composite model instances and ensure type safety. The most important changes include modifying the `create_composite_model_instance` method to accept a dictionary of Pydantic model instances, updating comments and data handling in the `__call__` method, and adding the `cast` function from the `typing` module.

Improvements to composite model handling:

* [`backend/pyspur/nodes/base.py`](diffhunk://#diff-e03060fb5e2d44df95d12f35d4a51184ef428760e0c0ef780ab1704003ca0cd6L143-R157): Modified the `create_composite_model_instance` method to accept a dictionary of Pydantic model instances instead of a list, and updated the method to create fields named after the dictionary keys.

Code comments and data handling updates:

* [`backend/pyspur/nodes/base.py`](diffhunk://#diff-e03060fb5e2d44df95d12f35d4a51184ef428760e0c0ef780ab1704003ca0cd6L188-R196): Updated comments in the `__call__` method to reflect that the input can be a dictionary of `BaseNodeOutput` or `BaseNodeInput` instances, and modified the data handling to preserve original keys when creating the composite model instance.

Type safety improvements:

* [`backend/pyspur/nodes/base.py`](diffhunk://#diff-e03060fb5e2d44df95d12f35d4a51184ef428760e0c0ef780ab1704003ca0cd6L4-R4): Added the `cast` function from the `typing` module to ensure type safety when handling composite inputs.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes composite input handling in `base.py` to preserve original node IDs, ensuring correct functionality for SingleLLMCallNode templates.
> 
>   - **Backend**:
>     - In `base.py`, `create_composite_model_instance` now accepts a dictionary of Pydantic model instances, preserving original node IDs as keys.
>     - Updated `__call__` method to handle input as a dictionary of `BaseNodeOutput` or `BaseNodeInput`, preserving keys when creating composite models.
>     - Added `cast` from `typing` for type safety.
>   - **Frontend**:
>     - In `NodeSidebar.tsx`, filtered out `enable_message_history` and `message_history_variable` from template fields.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for 97418092dedf02b34fc1764efdd16d49832fff98. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->