### PR TITLE
bug fix: remove print and logger statements

### DIFF
--- a/backend/pyspur/nodes/decorator.py
+++ b/backend/pyspur/nodes/decorator.py
@@ -227,8 +227,6 @@ def tool_function(
                 # config values can be jinja2 templates so we need to render them
                 for param_name, param_value in kwargs.items():
                     if isinstance(param_value, str):
-                        logger.debug(f"Rendering template for {param_name}: {param_value}")
-                        print(f"Input: {input}")
                         template = Template(param_value)
                         kwargs[param_name] = template.render(input=input)
 


### PR DESCRIPTION
This pull request includes a small change to the `backend/pyspur/nodes/decorator.py` file. The change removes debug logging and a print statement from the `run` method to clean up the code.

* [`backend/pyspur/nodes/decorator.py`](diffhunk://#diff-20d6b161ac59f787707c4886b67e6a8530c2ef6fe5060b52415ea7536bd3807fL230-L231): Removed debug logging and print statement from the `run` method to clean up the code.