### PR TITLE
chore: bump version to 0.1.9

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyspur"
-version = "0.1.8"
+version = "0.1.9"
 description = "PySpur is a Graph UI for building AI Agents in Python"
 requires-python = ">=3.11"
 license = "Apache-2.0"
@@ -138,4 +138,3 @@ check_untyped_defs = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
-addopts = "-v --cov=pyspur --cov-report=term-missing"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump version to 0.1.9 and remove `addopts` from `pyproject.toml`.
> 
>   - **Version Update**:
>     - Bump version from `0.1.8` to `0.1.9` in `pyproject.toml`.
>   - **Configuration Changes**:
>     - Remove `addopts` option from `[tool.pytest.ini_options]` in `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for 9b39bf0af332ea5011173465b80d92809e6b32ad. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->