### PR TITLE
Feat: render PDFs inside run modal

### DIFF
--- a/frontend/src/components/modals/RunModal.tsx
+++ b/frontend/src/components/modals/RunModal.tsx
@@ -234,7 +234,7 @@ const RunModal: React.FC<RunModalProps> = ({ isOpen, onOpenChange, onRun, onSave
             if (extension === 'pdf') {
                 return (
                     <div className="w-full">
-                        <iframe
+                        <iframe sandbox=""
                             src={filePath}
                             style={{ width: '100%', height: '240px', border: 'none' }}
                             className="rounded-md"

--- a/frontend/src/components/modals/RunModal.tsx
+++ b/frontend/src/components/modals/RunModal.tsx
@@ -230,6 +230,26 @@ const RunModal: React.FC<RunModalProps> = ({ isOpen, onOpenChange, onRun, onSave
                 )
             }
 
+            // Handle PDFs
+            if (extension === 'pdf') {
+                return (
+                    <div className="w-full">
+                        <iframe
+                            src={filePath}
+                            style={{ width: '100%', height: '240px', border: 'none' }}
+                            className="rounded-md"
+                            title={`PDF: ${fileName}`}
+                        />
+                        <div className="flex items-center gap-2 mt-1">
+                            <Icon icon="material-symbols:description" className="text-primary" />
+                            <Tooltip content={content} showArrow={true}>
+                                <span className="truncate text-xs">{fileName}</span>
+                            </Tooltip>
+                        </div>
+                    </div>
+                )
+            }
+
             // Handle audio
             if (['mp3', 'wav', 'ogg', 'm4a'].includes(extension)) {
                 return (


### PR DESCRIPTION
This pull request includes an enhancement to the `RunModal` component in the `frontend/src/components/modals/RunModal.tsx` file. The most significant change is the addition of functionality to handle PDF files.

Enhancements to `RunModal` component:

* [`frontend/src/components/modals/RunModal.tsx`](diffhunk://#diff-ab4ae89c478edfe7f7e7759ff63b7f1d6d3b13553348be9485c23696ddf8cad6R233-R252): Added a new block to handle PDF files, which includes rendering an iframe to display the PDF and a tooltip for the file name.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add PDF rendering capability to `RunModal` component in `RunModal.tsx`.
> 
>   - **Enhancement to `RunModal`**:
>     - In `RunModal.tsx`, added PDF handling in `renderCell()` function.
>     - Renders PDFs using an `iframe` with a tooltip for the file name.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for a16ef97e73209c2b57afb8a88555a30d8f3c544d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->