### PR TITLE
fix: remove sandbox

### DIFF
--- a/frontend/src/components/modals/RunModal.tsx
+++ b/frontend/src/components/modals/RunModal.tsx
@@ -234,7 +234,7 @@ const RunModal: React.FC<RunModalProps> = ({ isOpen, onOpenChange, onRun, onSave
             if (extension === 'pdf') {
                 return (
                     <div className="w-full">
-                        <iframe sandbox=""
+                        <iframe
                             src={filePath}
                             style={{ width: '100%', height: '240px', border: 'none' }}
                             className="rounded-md"


### PR DESCRIPTION
This pull request includes a small change to the `RunModal` component in the `frontend/src/components/modals/RunModal.tsx` file. The change involves modifying the `iframe` element to remove the `sandbox` attribute.

* [`frontend/src/components/modals/RunModal.tsx`](diffhunk://#diff-ab4ae89c478edfe7f7e7759ff63b7f1d6d3b13553348be9485c23696ddf8cad6L237-R237): Removed the `sandbox` attribute from the `iframe` element.