### PR TITLE
bump version to 0.1.11 in pyproject.toml

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyspur"
-version = "0.1.10"
+version = "0.1.11"
 description = "PySpur is a Graph UI for building AI Agents in Python"
 requires-python = ">=3.11"
 license = "Apache-2.0"


### PR DESCRIPTION
This pull request includes a version update for the `pyspur` project in the `backend/pyproject.toml` file. The version has been incremented from `0.1.10` to `0.1.11`.

* [`backend/pyproject.toml`](diffhunk://#diff-9f2cf60079756e94b31dbaeb145297215236d3c0135647163c2e51b80fd81551L7-R7): Updated project version from `0.1.10` to `0.1.11`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump version from `0.1.10` to `0.1.11` in `pyproject.toml`.
> 
>   - **Version Update**:
>     - Bump version from `0.1.10` to `0.1.11` in `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for 6f389011f73725071c8d7d32a7d65849985e6761. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->