### PR TITLE
fix: run with most recent test case

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -165,7 +165,10 @@ const Header: React.FC<HeaderProps> = ({ activePage, associatedWorkflowId, runId
                 return
             }
 
-            const testCase = testInputs.find((row) => row.id.toString() === selectedTestInputId) ?? testInputs[0]
+            // If a test case is explicitly selected, use that
+            // Otherwise, use the most recent test case (last one in the array)
+            const testCase = testInputs.find((row) => row.id.toString() === selectedTestInputId) ||
+                             testInputs[testInputs.length - 1]
 
             if (testCase) {
                 const { id, ...inputValues } = testCase

--- a/frontend/src/components/modals/RunModal.tsx
+++ b/frontend/src/components/modals/RunModal.tsx
@@ -86,22 +86,6 @@ const RunModal: React.FC<RunModalProps> = ({ isOpen, onOpenChange, onRun, onSave
         return maxId + 1
     }
 
-    const handleAddRow = () => {
-        // Check if we have any content to add
-        const hasContent = Object.values(editorContents).some((v) => v?.trim())
-        if (!hasContent) return
-
-        const newId = getNextId()
-        const newTestInput: TestInput = {
-            id: newId,
-            ...editorContents,
-        }
-        setTestData([...testData, newTestInput])
-        setEditorContents({}) // Clear editor contents
-        dispatch(addTestInput(newTestInput))
-        saveWorkflow()
-    }
-
     const handleDeleteRow = (id: number) => {
         setTestData(testData.filter((row) => row.id !== id))
         if (selectedTestInputId === id.toString()) {


### PR DESCRIPTION
This pull request includes changes to improve the handling of test cases and test inputs in the `Header` and `RunModal` components. The most important changes include updating the selection logic for test cases and removing the `handleAddRow` function.

Improvements to test case handling:

* [`frontend/src/components/Header.tsx`](diffhunk://#diff-c510609aa826d49ad460d88069bb38a03f4369437f399594f14aa6019327c9cdL168-R171): Modified the logic to select a test case. If a test case is explicitly selected, it will be used; otherwise, the most recent test case (last one in the array) will be used.

Codebase simplification:

* [`frontend/src/components/modals/RunModal.tsx`](diffhunk://#diff-ab4ae89c478edfe7f7e7759ff63b7f1d6d3b13553348be9485c23696ddf8cad6L89-L104): Removed the `handleAddRow` function, which was responsible for adding new rows of test inputs.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves test case handling by updating selection logic in `Header.tsx` and removing `handleAddRow` in `RunModal.tsx`.
> 
>   - **Test Case Handling**:
>     - In `Header.tsx`, updated test case selection logic to use explicitly selected test case or the most recent one if none is selected.
>   - **Code Simplification**:
>     - In `RunModal.tsx`, removed `handleAddRow` function, which added new test input rows.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for c4c6564946fb9771ffbcd9b5305ab9d4440b8586. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->