### PR TITLE
feat: add status filter to list runs and update TraceTable for status…

### DIFF
--- a/backend/pyspur/api/workflow_run.py
+++ b/backend/pyspur/api/workflow_run.py
@@ -715,6 +715,7 @@ def list_runs(
     end_date: Optional[datetime] = Query(
         default=None, description="Filter runs before this date (inclusive)"
     ),
+    status: Optional[RunStatus] = Query(default=None, description="Filter runs by status"),
     db: Session = Depends(get_db),
 ):
     offset = (page - 1) * page_size
@@ -725,6 +726,10 @@ def list_runs(
         query = query.filter(RunModel.start_time >= start_date)
     if end_date:
         query = query.filter(RunModel.start_time <= end_date)
+
+    # Apply status filter if provided
+    if status:
+        query = query.filter(RunModel.status == status)
 
     # Order by start time descending and apply pagination
     runs = query.order_by(RunModel.start_time.desc()).offset(offset).limit(page_size).all()

--- a/frontend/src/components/TraceTable.tsx
+++ b/frontend/src/components/TraceTable.tsx
@@ -198,6 +198,17 @@ const TraceTable: React.FC<TraceTableProps> = ({ workflowId }) => {
     const [page, setPage] = useState(1)
     const [hasMoreRuns, setHasMoreRuns] = useState(true)
     const [isLoadingMore, setIsLoadingMore] = useState(false)
+    const [selectedStatus, setSelectedStatus] = useState<RunStatus | ''>('')
+
+    const statusOptions: { label: string; value: RunStatus | '' }[] = [
+        { label: 'All', value: '' },
+        { label: 'Completed', value: 'COMPLETED' },
+        { label: 'Running', value: 'RUNNING' },
+        { label: 'Pending', value: 'PENDING' },
+        { label: 'Failed', value: 'FAILED' },
+        { label: 'Cancelled', value: 'CANCELLED' },
+        { label: 'Paused', value: 'PAUSED' },
+    ]
 
     const createUTCDate = (date: Date, time: string): Date => {
         const [hours, minutes] = time.split(':').map(Number)
@@ -223,7 +234,14 @@ const TraceTable: React.FC<TraceTableProps> = ({ workflowId }) => {
                 end = createUTCDate(new Date(endDate.toString()), endTime)
             }
 
-            const workflowRuns = await getWorkflowRuns(workflowId, currentPage, parseInt(numRuns), start, end)
+            const workflowRuns = await getWorkflowRuns(
+                workflowId,
+                currentPage,
+                parseInt(numRuns),
+                start,
+                end,
+                selectedStatus || undefined
+            )
 
             // Sort runs by start time in descending order (newest first)
             const sortedRuns = workflowRuns.sort((a, b) => {
@@ -265,7 +283,7 @@ const TraceTable: React.FC<TraceTableProps> = ({ workflowId }) => {
         }, 5000) // Poll every 5 seconds if there are active runs
 
         return () => clearInterval(intervalId)
-    }, [workflowId, startDate, endDate, startTime, endTime, numRuns])
+    }, [workflowId, startDate, endDate, startTime, endTime, numRuns, selectedStatus])
 
     const handleApplyFilter = () => {
         setPage(1)
@@ -278,6 +296,7 @@ const TraceTable: React.FC<TraceTableProps> = ({ workflowId }) => {
         setStartTime('00:00')
         setEndTime('23:59')
         setNumRuns('100')
+        setSelectedStatus('')
         setPage(1)
     }
 
@@ -349,6 +368,20 @@ const TraceTable: React.FC<TraceTableProps> = ({ workflowId }) => {
                         <SelectItem key="200" value="200">
                             200 runs
                         </SelectItem>
+                    </Select>
+                </div>
+                <div className="flex flex-col gap-2">
+                    <label className="text-sm text-default-600">Status</label>
+                    <Select
+                        value={selectedStatus}
+                        onChange={(e) => setSelectedStatus(e.target.value as RunStatus | '')}
+                        className="min-w-[150px]"
+                    >
+                        {statusOptions.map((option) => (
+                            <SelectItem key={option.value} value={option.value}>
+                                {option.label}
+                            </SelectItem>
+                        ))}
                     </Select>
                 </div>
                 <div className="flex gap-2">

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -22,7 +22,7 @@ import {
     VectorIndexCreateRequestSchema,
     VectorIndexResponseSchema,
 } from '@/types/api_types/ragSchemas'
-import { RunResponse } from '@/types/api_types/runSchemas'
+import { RunResponse, RunStatus } from '@/types/api_types/runSchemas'
 import { SessionCreate, SessionListResponse, SessionResponse } from '@/types/api_types/sessionSchemas'
 import { UserCreate, UserListResponse, UserResponse, UserUpdate } from '@/types/api_types/userSchemas'
 import {
@@ -211,7 +211,8 @@ export async function getWorkflowRuns(
     page: number = 1,
     pageSize: number = 10,
     startDate?: Date,
-    endDate?: Date
+    endDate?: Date,
+    status?: RunStatus
 ): Promise<RunResponse[]> {
     let url = `${API_BASE_URL}/wf/${workflowId}/runs/?page=${page}&page_size=${pageSize}`
 
@@ -221,6 +222,10 @@ export async function getWorkflowRuns(
     }
     if (endDate) {
         url += `&end_date=${endDate.toISOString()}`
+    }
+    // Add status filter if provided
+    if (status) {
+        url += `&status=${status}`
     }
 
     try {


### PR DESCRIPTION
This pull request introduces a new feature to filter workflow runs by their status. The changes span both backend and frontend code to support this new feature. The most important changes include adding the status filter to the backend API, updating the frontend components to include a status dropdown, and modifying the API utility functions to handle the new filter.

Backend changes:

* [`backend/pyspur/api/workflow_run.py`](diffhunk://#diff-63f1d1a2ea8af263f380898d33fa9495d57346805a3147d93e4704060fc65243R718): Added a `status` parameter to the `list_runs` function and applied the status filter to the query if provided. [[1]](diffhunk://#diff-63f1d1a2ea8af263f380898d33fa9495d57346805a3147d93e4704060fc65243R718) [[2]](diffhunk://#diff-63f1d1a2ea8af263f380898d33fa9495d57346805a3147d93e4704060fc65243R730-R733)

Frontend changes:

* [`frontend/src/components/TraceTable.tsx`](diffhunk://#diff-fc41dd1f629ae4fd8403ce0b1576e00f5e116d742c7fcdbaed9da580ebc2fe0aR201-R211): Introduced a `selectedStatus` state and a dropdown for status options, updated the `getWorkflowRuns` function call to include the `selectedStatus`, and modified the dependencies of the useEffect hook to include `selectedStatus`. [[1]](diffhunk://#diff-fc41dd1f629ae4fd8403ce0b1576e00f5e116d742c7fcdbaed9da580ebc2fe0aR201-R211) [[2]](diffhunk://#diff-fc41dd1f629ae4fd8403ce0b1576e00f5e116d742c7fcdbaed9da580ebc2fe0aL226-R244) [[3]](diffhunk://#diff-fc41dd1f629ae4fd8403ce0b1576e00f5e116d742c7fcdbaed9da580ebc2fe0aL268-R286) [[4]](diffhunk://#diff-fc41dd1f629ae4fd8403ce0b1576e00f5e116d742c7fcdbaed9da580ebc2fe0aR299) [[5]](diffhunk://#diff-fc41dd1f629ae4fd8403ce0b1576e00f5e116d742c7fcdbaed9da580ebc2fe0aR373-R386)

API utility changes:

* [`frontend/src/utils/api.ts`](diffhunk://#diff-2beb6ebeac073ebc54270b993a4433163fc86d1174554f001f706f026eb11e9dL25-R25): Updated the `getWorkflowRuns` function to accept a `status` parameter and include it in the API request URL if provided. [[1]](diffhunk://#diff-2beb6ebeac073ebc54270b993a4433163fc86d1174554f001f706f026eb11e9dL25-R25) [[2]](diffhunk://#diff-2beb6ebeac073ebc54270b993a4433163fc86d1174554f001f706f026eb11e9dL214-R215) [[3]](diffhunk://#diff-2beb6ebeac073ebc54270b993a4433163fc86d1174554f001f706f026eb11e9dR226-R229)… selection