### PR TITLE
feat: add get_node_title_output_map function to map node titles to ou…

### DIFF
--- a/backend/pyspur/nodes/llm/agent.py
+++ b/backend/pyspur/nodes/llm/agent.py
@@ -103,7 +103,7 @@ class AgentNode(SingleLLMCallNode):
         for tool in tools:
             # Create node instance
             tool_node_instance = NodeFactory.create_node(
-                node_name=tool.id,
+                node_name=tool.title,
                 node_type_name=tool.node_type,
                 config=tool.config,
             )
@@ -131,7 +131,7 @@ class AgentNode(SingleLLMCallNode):
                 tool_schema = tool.function_schema
             else:
                 tool_node_instance = NodeFactory.create_node(
-                    node_name=tool.id,
+                    node_name=tool.title,
                     node_type_name=tool.node_type,
                     config=tool.config,
                 )
@@ -155,7 +155,7 @@ class AgentNode(SingleLLMCallNode):
 
         # Create node instance
         tool_node_instance = NodeFactory.create_node(
-            node_name=tool_node.id,
+            node_name=tool_node.title,
             node_type_name=tool_node.node_type,
             config=tool_node.config,
         )

--- a/frontend/src/components/nodes/loops/groupNodeUtils.ts
+++ b/frontend/src/components/nodes/loops/groupNodeUtils.ts
@@ -11,6 +11,7 @@ import { AppDispatch } from '@/store/store'
 import { createNode } from '@/utils/nodeFactory'
 
 import { updateNodeParentAndCoordinates } from '../../../store/flowSlice'
+import { v4 as uuidv4 } from 'uuid'
 
 export const GROUP_NODE_TYPES = ['ForLoopNode']
 
@@ -22,7 +23,7 @@ export const sortNodes = (a: Node, b: Node): number => {
     return a.type === 'group' && b.type !== 'group' ? -1 : 1
 }
 
-export const getId = (prefix = 'node') => `${prefix}_${Math.random() * 10000}`
+export const getId = (prefix = 'node') => `${prefix}_${uuidv4()}`
 
 export const getNodePositionInsideParent = (node: Partial<Node>, groupNode: Node) => {
     const position = node.position ?? { x: 0, y: 0 }
@@ -208,35 +209,44 @@ export const createDynamicGroupNodeWithChildren = (
     nodeType: string,
     id: string,
     position: { x: number; y: number },
-    dispatch: AppDispatch
+    dispatch: AppDispatch,
+    title?: string
 ) => {
-    const loopNodeAndConfig = createNode(nodeTypes, nodeType, id, position, null, { width: 1200, height: 600 })
+    const loopNodeAndConfig = createNode(nodeTypes, nodeType, id, position, null, { width: 1200, height: 600 }, title)
 
     if (loopNodeAndConfig) {
         // Set initial dimensions for the loop node
 
-        // Create input node
+        // Create input node with readable title but UUID id
+        const inputNodeId = uuidv4()
+        const inputNodeTitle = title ? `${title}_input` : `${nodeType}_input`
         const inputNodeAndConfig = createNode(
             nodeTypes,
             'InputNode',
-            `${id}_input`,
+            inputNodeId,
             {
                 x: 0,
                 y: 300, // position.y + (height/2)
             },
-            loopNodeAndConfig.node.id
+            loopNodeAndConfig.node.id,
+            null,
+            inputNodeTitle
         )
 
-        // Create output node
+        // Create output node with readable title but UUID id
+        const outputNodeId = uuidv4()
+        const outputNodeTitle = title ? `${title}_output` : `${nodeType}_output`
         const outputNodeAndConfig = createNode(
             nodeTypes,
             'OutputNode',
-            `${id}_output`,
+            outputNodeId,
             {
                 x: 950, // position.x + width - 250
                 y: 300, // position.y + (height/2)
             },
-            loopNodeAndConfig.node.id
+            loopNodeAndConfig.node.id,
+            null,
+            outputNodeTitle
         )
 
         // Set input node's output schema to be fixed but empty initially

--- a/frontend/src/store/flowSlice.ts
+++ b/frontend/src/store/flowSlice.ts
@@ -294,24 +294,27 @@ const flowSlice = createSlice({
             const { nodeId, nodeTypeName } = action.payload
             const node = state.nodes.find((n) => n.id === nodeId)
             if (node) {
-                // Generate a new ID following the same pattern as other nodes
-                const existingIds = state.nodes.map((node) => node.id)
+                // Generate a readable title
                 const sanitizedType = nodeTypeName.replace(/\s+/g, '_').replace(/Node/g, 'Tool')
+                const existingTitles = state.nodes.map((node) => node.data?.title)
                 let counter = 1
-                let newId = `${sanitizedType}_${counter}`
-                while (existingIds.includes(newId)) {
+                let newTitle = `${sanitizedType}_${counter}`
+                
+                while (existingTitles.includes(newTitle)) {
                     counter++
-                    newId = `${sanitizedType}_${counter}`
+                    newTitle = `${sanitizedType}_${counter}`
                 }
 
-                // Create the new node using createNode
+                // Create the new node using createNode with UUID for ID but readable title
                 const result = createNode(
                     // @ts-ignore - nodeTypes will be properly typed at runtime
                     state.nodeTypes,
                     nodeTypeName,
-                    newId,
+                    uuidv4(), // Use UUID for ID
                     { x: 0, y: 0 },
-                    nodeId // Set parentId to the agent node's ID
+                    nodeId, // Set parentId to the agent node's ID
+                    null,   // No dimensions provided
+                    newTitle // Provide the readable title
                 )
 
                 if (result) {

--- a/frontend/src/utils/flowUtils.tsx
+++ b/frontend/src/utils/flowUtils.tsx
@@ -91,7 +91,6 @@ export const getNodeTitle = (data: FlowWorkflowNode['data']): string => {
 }
 
 const generateNewNodeTitle = (nodes: FlowWorkflowNode[], nodeType: string): string => {
-    // Use UUID v4 for unique IDs instead of readable format
     const existingTitles = nodes.map((node) => node.data?.title)
     const sanitizedType = nodeType.replace(/\s+/g, '_')
     let counter = 1


### PR DESCRIPTION
This pull request includes changes to the `backend/pyspur/api/workflow_run.py` file to improve the handling of node outputs in workflow runs. The primary focus is on refactoring the code to use a new helper function for mapping node titles to their outputs.

Refactoring and code simplification:

* Added import for `BaseNodeOutput` in `backend/pyspur/api/workflow_run.py` to support the new helper function.
* Introduced the `get_node_title_output_map` function to create a dictionary mapping node titles to their outputs.
* Updated `async def run_workflow_blocking_v2` to use the new `get_node_title_output_map` function, simplifying the code for creating the outputs dictionary. [[1]](diffhunk://#diff-63f1d1a2ea8af263f380898d33fa9495d57346805a3147d93e4704060fc65243L183-R199) [[2]](diffhunk://#diff-63f1d1a2ea8af263f380898d33fa9495d57346805a3147d93e4704060fc65243L202-R213)
* Modified `async def run_workflow_blocking` to use the new helper function for setting the outputs.
* Updated `async def run_workflow_task` and `_handle_pause_exception` to use the `get_node_title_output_map` function, ensuring consistency in how outputs are handled. [[1]](diffhunk://#diff-63f1d1a2ea8af263f380898d33fa9495d57346805a3147d93e4704060fc65243L433-R446) [[2]](diffhunk://#diff-63f1d1a2ea8af263f380898d33fa9495d57346805a3147d93e4704060fc65243L513-R528)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces `get_node_title_output_map` for mapping node titles to outputs and updates frontend to use UUIDs for node IDs and readable titles.
> 
>   - **Backend Changes**:
>     - Added `get_node_title_output_map` in `workflow_run.py` to map node titles to outputs.
>     - Updated `run_workflow_blocking_v2`, `run_workflow_blocking`, `run_workflow_task`, and `_handle_pause_exception` to use `get_node_title_output_map`.
>   - **Frontend Changes**:
>     - Updated `createDynamicGroupNodeWithChildren` in `groupNodeUtils.ts` to use UUIDs for node IDs and readable titles.
>     - Modified `addToolToAgent` and `duplicateNode` in `flowSlice.ts` to generate readable titles and use UUIDs for IDs.
>     - Updated `createNodeAtCenter` and `duplicateNode` in `flowUtils.tsx` to use UUIDs for IDs and generate readable titles.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for 544201d3419b049b5de8099303427abd0cdd0d86. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->