### PR TITLE
Fix node title generation to use UUIDs

### DIFF
--- a/frontend/src/utils/flowUtils.tsx
+++ b/frontend/src/utils/flowUtils.tsx
@@ -113,10 +113,10 @@ export const createNodeAtCenter = (
 ): void => {
     // Generate UUID for the node ID
     const id = uuidv4()
-    
+
     // Create a human-readable title (similar to previous ID format)
     const nodeTitle = generateNewNodeTitle(nodes, nodeType)
-    
+
     const center = reactFlowInstance.screenToFlowPosition({
         x: window.innerWidth / 2,
         y: window.innerHeight / 2,
@@ -165,8 +165,8 @@ export const duplicateNode = (nodeId: string, dispatch: AppDispatch, getState: (
 
     // Generate a new unique ID for the duplicated node using UUID
     const newNodeId = uuidv4()
-    
-    // Create a title based on the original node's title 
+
+    // Create a title based on the original node's title
     const newNodeTitle = generateNewNodeTitle(nodes, sourceNode.type || 'default')
 
     // Create the new node with an offset position
@@ -221,7 +221,7 @@ export const duplicateNode = (nodeId: string, dispatch: AppDispatch, getState: (
         childNodes.forEach((childNode) => {
             const newChildId = uuidv4()
             idMapping[childNode.id] = newChildId
-            
+
             // Create readable title for the child node
             const newChildTitle = generateNewNodeTitle(nodes, childNode.type || 'default')
             const newChildNode = {
@@ -304,14 +304,18 @@ export const insertNodeBetweenNodes = (
         return
     }
 
-    const id = generateNewNodeId(nodes, nodeType)
+    // Generate UUID for the node ID
+    const id = uuidv4()
+
+    // Create a human-readable title (similar to previous ID format)
+    const nodeTitle = generateNewNodeTitle(nodes, nodeType)
     const newPosition = {
         x: (sourceNode.position.x + targetNode.position.x) / 2,
         y: (sourceNode.position.y + targetNode.position.y) / 2,
     }
 
     // Create the new node
-    const result = createNode(nodeTypes, nodeType, id, newPosition)
+    const result = createNode(nodeTypes, nodeType, id, newPosition, null, null, nodeTitle)
     if (!result) {
         console.error('Failed to create node')
         return


### PR DESCRIPTION
Update node creation to generate titles based on UUIDs, ensuring unique identification and improved readability.