### PR TITLE
feat: add o1-pro

### DIFF
--- a/backend/pyspur/nodes/llm/_model_info.py
+++ b/backend/pyspur/nodes/llm/_model_info.py
@@ -82,6 +82,7 @@ class LLMModel(BaseModel):
 
 class LLMModels(str, Enum):
     # OpenAI Models
+    O1_PRO = "openai/o1-pro"
     O3_MINI = "openai/o3-mini"
     O3_MINI_2025_01_31 = "openai/o3-mini-2025-01-31"
     GPT_4O_MINI = "openai/gpt-4o-mini"
@@ -203,6 +204,18 @@ class LLMModels(str, Enum):
                     max_temperature=2.0,
                     supports_max_tokens=False,
                     supports_temperature=False,
+                ).add_mime_categories({MimeCategory.IMAGES}),
+            ),
+            cls.O1_PRO.value: LLMModel(
+                id=cls.O1_PRO.value,
+                provider=LLMProvider.OPENAI,
+                name="O1 Pro",
+                constraints=ModelConstraints(
+                    max_tokens=100000,
+                    max_temperature=2.0,
+                    supports_max_tokens=False,
+                    supports_temperature=False,
+                    supports_JSON_output=True,
                 ).add_mime_categories({MimeCategory.IMAGES}),
             ),
             cls.O1_2024_12_17.value: LLMModel(


### PR DESCRIPTION
This pull request includes updates to the `backend/pyspur/nodes/llm/_model_info.py` file to add support for a new model. The most important changes are as follows:

### Addition of new model:

* [`backend/pyspur/nodes/llm/_model_info.py`](diffhunk://#diff-9d849dd74d758e4fe103885965d5b8a61fba488d19f61340572ebcc4e6a05b32R85): Added the new model `O1_PRO` to the `LLMModels` enum.
* [`backend/pyspur/nodes/llm/_model_info.py`](diffhunk://#diff-9d849dd74d758e4fe103885965d5b8a61fba488d19f61340572ebcc4e6a05b32R209-R220): Updated the `get_model_info` method to include the new `O1_PRO` model with its associated properties and constraints.