### PR TITLE
fix: switch from alpine to slim variant for Node.js in Dockerfiles

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -18,7 +18,7 @@ ENV PYTHONPATH=/pyspur/backend
 # Development-specific instructions here
 
 # Frontend build stage
-FROM node:23-alpine AS frontend-builder
+FROM node:23-slim AS frontend-builder
 WORKDIR /pyspur/frontend
 COPY frontend/package*.json ./
 RUN npm ci

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,4 +1,4 @@
-FROM node:23-alpine AS base
+FROM node:23-slim AS base
 WORKDIR /pyspur/frontend
 COPY frontend/package*.json ./
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Switch Node.js base image from `alpine` to `slim` in `Dockerfile.backend` and `Dockerfile.frontend`.
> 
>   - **Dockerfiles**:
>     - Change Node.js base image from `node:23-alpine` to `node:23-slim` in `Dockerfile.backend` and `Dockerfile.frontend`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for e20b2b269b56141177cd98f5dc6c02aeb28cd240. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->