### PR TITLE
Allow for references to models

### DIFF
--- a/backend/pyspur/nodes/llm/_utils.py
+++ b/backend/pyspur/nodes/llm/_utils.py
@@ -222,6 +222,9 @@ def sanitize_json_schema(schema: Dict[str, Any]) -> Dict[str, Any]:
             if key not in schema["required"]:
                 schema["required"].append(key)
             sanitize_json_schema(value)
+    if "$defs" in schema:
+        for key in schema["$defs"]:
+            schema["$defs"][key] = sanitize_json_schema(schema["$defs"][key])
     return schema
 
 


### PR DESCRIPTION
This patch allows for things like (json schema equivalent of):

```python
    class TestModel(BaseModel):
        name: str
        age: int

    class TestSubModel(BaseModel):
        students: List[TestModel]
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance JSON schema to Pydantic model conversion by supporting `$defs` and `$ref` for nested model references.
> 
>   - **Behavior**:
>     - Support for `$defs` and `$ref` in JSON schema added to `sanitize_json_schema()` in `_utils.py`.
>     - `json_schema_to_model()` in `pydantic_utils.py` now processes `$defs` for nested model references.
>     - `json_schema_to_pydantic_field()` and `json_schema_to_pydantic_type()` updated to handle references using `$ref`.
>   - **Testing**:
>     - Added test cases for `TestModel` and `TestSubModel` to verify model conversion with references in `pydantic_utils.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for ba06f13c8f4efea7e51a4e3a510921714d8b4800. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->