### PR TITLE
Add models for OpenAI 4o Search and Mini Search

### DIFF
--- a/backend/pyspur/nodes/llm/_model_info.py
+++ b/backend/pyspur/nodes/llm/_model_info.py
@@ -87,6 +87,8 @@ class LLMModels(str, Enum):
     O3_MINI_2025_01_31 = "openai/o3-mini-2025-01-31"
     GPT_4O_MINI = "openai/gpt-4o-mini"
     GPT_4O = "openai/gpt-4o"
+    GPT_4O_MINI_SEARCH_PREVIEW = "openai/gpt-4o-mini-search-preview"
+    GPT_4O_SEARCH_PREVIEW = "openai/gpt-4o-search-preview"
     O1_PREVIEW = "openai/o1-preview"
     O1_MINI = "openai/o1-mini"
     O1 = "openai/o1"
@@ -178,6 +180,24 @@ class LLMModels(str, Enum):
                 constraints=ModelConstraints(
                     max_tokens=16384, max_temperature=2.0
                 ).add_mime_categories({MimeCategory.IMAGES}),
+            ),
+            cls.GPT_4O_MINI_SEARCH_PREVIEW.value: LLMModel(
+                    id=cls.GPT_4O_MINI_SEARCH_PREVIEW.value,
+                    provider=LLMProvider.OPENAI,
+                    name="GPT-4O Mini Search Preview",
+                    constraints=ModelConstraints(
+                            max_tokens=16384,
+                            supports_temperature=False
+                    ).add_mime_categories({MimeCategory.IMAGES}),
+            ),
+            cls.GPT_4O_SEARCH_PREVIEW.value: LLMModel(
+                    id=cls.GPT_4O_SEARCH_PREVIEW.value,
+                    provider=LLMProvider.OPENAI,
+                    name="GPT-4O Search Preview",
+                    constraints=ModelConstraints(
+                            max_tokens=16384,
+                            supports_temperature=False
+                    ).add_mime_categories({MimeCategory.IMAGES}),
             ),
             cls.O1_PREVIEW.value: LLMModel(
                 id=cls.O1_PREVIEW.value,


### PR DESCRIPTION
add OpenAI 4o Search and Mini Search models. Using the preview models for now
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `GPT_4O_MINI_SEARCH_PREVIEW` and `GPT_4O_SEARCH_PREVIEW` models to `LLMModels` in `_model_info.py` with specific constraints.
> 
>   - **Models**:
>     - Add `GPT_4O_MINI_SEARCH_PREVIEW` and `GPT_4O_SEARCH_PREVIEW` to `LLMModels` enum in `_model_info.py`.
>     - Update `get_model_info()` to include new models with constraints: max tokens 16384, no temperature support, and image MIME category.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for 1350830b916437c229dbab81a7a50e9106e738e9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->