### PR TITLE
add xAI as a provider and Grok to the models

### DIFF
--- a/backend/pyspur/nodes/llm/_model_info.py
+++ b/backend/pyspur/nodes/llm/_model_info.py
@@ -17,6 +17,7 @@ class LLMProvider(str, Enum):
     OLLAMA = "ollama"
     AZURE_OPENAI = "azure"
     DEEPSEEK = "deepseek"
+    XAI = "xai"
 
 
 class ModelConstraints(BaseModel):
@@ -137,6 +138,8 @@ class LLMModels(str, Enum):
     OLLAMA_MISTRAL = "ollama/mistral"
     OLLAMA_CODELLAMA = "ollama/codellama"
     OLLAMA_MIXTRAL = "ollama/mixtral-8x7b-instruct-v0.1"
+
+    XAI_GROK_2 = "xai/grok-2-latest"
 
     @classmethod
     def get_model_info(cls, model_id: str) -> LLMModel | None:
@@ -550,6 +553,15 @@ class LLMModels(str, Enum):
                 provider=LLMProvider.OLLAMA,
                 name="Mistral Small 24B",
                 constraints=ModelConstraints(max_tokens=4096, max_temperature=2.0, supports_JSON_output=False),
+            ),
+            cls.XAI_GROK_2.value: LLMModel(
+                    id=cls.XAI_GROK_2.value,
+                    provider=LLMProvider.XAI,
+                    name="xAI Grok 2 Latest",
+                    constraints=ModelConstraints(
+                            max_tokens=131072,
+                            max_temperature=1.0,
+                    ),
             ),
         }
         return model_registry.get(model_id)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `XAI` provider and `xAI Grok 2 Latest` model to `_model_info.py` with specific constraints.
> 
>   - **Providers**:
>     - Add `XAI` to `LLMProvider` enum in `_model_info.py`.
>   - **Models**:
>     - Add `XAI_GROK_2` to `LLMModels` enum in `_model_info.py`.
>     - Add `xAI Grok 2 Latest` model to `get_model_info()` with constraints: `max_tokens=131072`, `max_temperature=1.0`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for bf2d1691ff5d06224a495e4dad86c9fecb057066. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->