### PR TITLE
Update tiktoken to support MacOS

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -66,7 +66,7 @@ dependencies = [
     "supabase==2.11.0",
     "six==1.17.0",
     "tenacity==8.3.0",
-    "tiktoken==0.7.0",
+    "tiktoken==0.9.0",
     "tqdm==4.67.1",
     "weaviate_client==4.10.2",
     "itsdangerous==2.2.0",


### PR DESCRIPTION
Hello,

When trying to install pyspur it failed due to building wheels of tiktoken.
Newer version of tiktoken is already built correctly, and AFAIK didn't change the functionality.
Hence IMHO updating is safe.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `tiktoken` version in `pyproject.toml` to `0.9.0` for MacOS support.
> 
>   - **Dependencies**:
>     - Update `tiktoken` version from `0.7.0` to `0.9.0` in `pyproject.toml` to support MacOS.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=PySpur-Dev%2Fpyspur&utm_source=github&utm_medium=referral)<sup> for ead50009d024bc24c2cf56d48799da01c30843db. You can [customize](https://app.ellipsis.dev/PySpur-Dev/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->