### PR TITLE
fix: handle enum types correctly in json_schema_to_model

### DIFF
--- a/backend/pyspur/utils/pydantic_utils.py
+++ b/backend/pyspur/utils/pydantic_utils.py
@@ -44,7 +44,23 @@ def json_schema_to_model(
     model_name = model_class_name
 
     schema_defs = json_schema.get('$defs', {})
-    defs = {name: json_schema_to_model(definition, name) for name, definition in schema_defs.items()}
+    defs: Dict[str, Any] = {}
+    for name, definition in schema_defs.items():
+        if 'enum' in definition:
+            # Enum definitions should map to their base Python type, not a Pydantic model
+            base_type = definition.get('type', 'string')
+            if base_type == 'string':
+                defs[name] = str
+            elif base_type == 'integer':
+                defs[name] = int
+            elif base_type == 'number':
+                defs[name] = float
+            elif base_type == 'boolean':
+                defs[name] = bool
+            else:
+                defs[name] = Any
+        else:
+            defs[name] = json_schema_to_model(definition, name)
 
     # Extract the field definitions from the schema properties.
     field_definitions = {


### PR DESCRIPTION
Fixes #291

## Problem

`SendEmailNode` (and other nodes with `has_fixed_output=True` and enum fields) throws a Pydantic validation error at runtime:

```
ValidationError: 1 validation error for SendEmailNode_1
provider
  Input should be a valid dictionary or instance of EmailProvider
  [type=model_type, input_value=<EmailProvider.RESEND: 'resend'>, input_type=EmailProvider]
```

**Root cause**: When `setup()` processes `output_json_schema` for a node with `has_fixed_output=True`, it calls `json_schema_to_model()`. That function recursively calls itself on every `$defs` entry — including enum definitions like `EmailProvider`. Because enum schemas have no `properties`, `json_schema_to_model` creates an empty Pydantic model for them. Later, when `json_schema_to_pydantic_type` resolves the `$ref`, the field type becomes that empty model instead of `str`. Pydantic then rejects the actual enum value with "Input should be a valid dictionary or instance of EmailProvider".

## Solution

In `json_schema_to_model`, before recursively converting a `$defs` entry, check whether the definition contains an `"enum"` field. If it does, map it to the appropriate Python primitive type (`str`, `int`, `float`, `bool`) instead of creating a Pydantic model. This correctly handles all JSON Schema enum types that reference a primitive base type.

## Testing

Manually traced the code path for `SendEmailNodeOutput.model_json_schema()`:
- `EmailProvider` definition (`{"enum": ["resend", "sendgrid"], "type": "string"}`) now maps to `str` in `defs`
- `provider` field resolves to `str`, accepting both enum instances and raw string values
- Existing model/object definitions continue to be processed via `json_schema_to_model` as before