### PR TITLE
fix: pin click<8.2 to prevent CLI crash on startup

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -78,6 +78,7 @@ dependencies = [
     "sendgrid==6.11.0",
     "resend==2.6.0",
     "typer[all]==0.9.0",
+    "click<8.2",
     "psutil>=7.0.0",
 ]
 


### PR DESCRIPTION
Fixes #294

## Problem

Running `pyspur init` (or any CLI command) fails immediately with:

```
TypeError: Secondary flag is not valid for non-boolean flag.
```

The full traceback ends at `click/core.py` inside `Option.__init__`. This is a **breaking change introduced in click 8.2.0**, which added strict validation that secondary flags (e.g., `--flag/--no-flag`) may only be applied to boolean options. `typer==0.9.0` (currently pinned) generates option definitions that trigger this check when click 8.2+ is installed.

The workaround confirmed by users is `pip install "click<8.2"`, but without an explicit upper bound in `pyproject.toml` the broken version gets pulled in automatically.

## Solution

Add `"click<8.2"` as an explicit dependency constraint. This keeps `typer==0.9.0` working correctly without requiring an immediate typer upgrade (which would risk larger API-level breaking changes).

## Testing

- Installing with `pip install "click<8.2"` restores `pyspur init` functionality (confirmed by multiple users in the issue thread)
- The constraint is consistent with what typer 0.9.0 was designed and tested against