### PR TITLE
fix: use Path(str()) instead of resources.as_file() for alembic dir on Python < 3.12

### DIFF
--- a/backend/pyspur/cli/utils.py
+++ b/backend/pyspur/cli/utils.py
@@ -121,11 +121,12 @@ def run_migrations() -> None:
             if not script_location.is_dir():
                 raise FileNotFoundError("Migration scripts not found in package")
 
-            # extract migration scripts directory to a temporary location
-            with (
-                tempfile.TemporaryDirectory() as script_temp_dir,
-                resources.as_file(script_location) as script_location_path,
-            ):
+            # Extract migration scripts to a temporary location for Alembic.
+            # resources.as_file() only supports files in Python < 3.12, so we
+            # convert the MultiplexedPath to a regular Path via str(), which
+            # returns the underlying filesystem path for installed packages.
+            with tempfile.TemporaryDirectory() as script_temp_dir:
+                script_location_path = Path(str(script_location))
                 shutil.copytree(script_location_path, Path(script_temp_dir), dirs_exist_ok=True)
                 # Create Alembic config programmatically
                 config = Config()


### PR DESCRIPTION
Fixes #273

## Problem

Running `pyspur serve` with a PostgreSQL database fails with:

```
Error running migrations: 
MultiplexedPath('/home/user/llm/lib/python3.11/site-packages/pyspur/models/management/alembic') is not a file
```

`importlib.resources.as_file()` only supports individual files in Python < 3.12. When called with a `MultiplexedPath` representing a **directory** (the alembic scripts folder), it raises:

```
TypeError: MultiplexedPath('...') is not a file
```

Python 3.12 extended `as_file()` to support directories, but PySpur supports Python 3.11+.

## Solution

Replace `resources.as_file(script_location)` with `Path(str(script_location))`.

For packages installed to the filesystem (i.e. regular `pip install`), `str(MultiplexedPath)` returns the underlying filesystem path directly, so we can pass it to `shutil.copytree()` without needing the context manager.

## Testing

Verified the changed code path no longer uses `as_file()` on a directory. The fix is a one-line change that removes the incompatible Python < 3.12 code path while preserving the same copy-to-temp-dir behavior.