### PR TITLE
Add MiniMax provider models and endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,18 @@ POSTGRES_PORT=5432
 # OPENAI_API_BASE=https://api.openai.com/v1
 
 # ======================
+# MiniMax Configuration
+# ======================
+
+# MINIMAX_API_KEY=your_minimax_api_key
+# MINIMAX_REGION=global_en
+# MINIMAX_PROTOCOL=openai
+# MINIMAX_GLOBAL_EN_OPENAI_API_BASE=https://api.minimax.io/v1
+# MINIMAX_GLOBAL_EN_ANTHROPIC_API_BASE=https://api.minimax.io/anthropic
+# MINIMAX_CN_ZH_OPENAI_API_BASE=https://api.minimaxi.com/v1
+# MINIMAX_CN_ZH_ANTHROPIC_API_BASE=https://api.minimaxi.com/anthropic
+
+# ======================
 # Ollama Configuration
 # ======================
 

--- a/backend/pyspur/api/key_management.py
+++ b/backend/pyspur/api/key_management.py
@@ -93,6 +93,45 @@ PROVIDER_CONFIGS = [
         ],
     ),
     ProviderConfig(
+        id="minimax",
+        name="MiniMax",
+        description="MiniMax models through compatible chat APIs",
+        category="llm",
+        parameters=[
+            ProviderParameter(name="MINIMAX_API_KEY", description="MiniMax API Key"),
+            ProviderParameter(
+                name="MINIMAX_REGION",
+                description="MiniMax endpoint region: global_en or cn_zh",
+                type="text",
+            ),
+            ProviderParameter(
+                name="MINIMAX_PROTOCOL",
+                description="MiniMax API protocol: openai or anthropic",
+                type="text",
+            ),
+            ProviderParameter(
+                name="MINIMAX_GLOBAL_EN_OPENAI_API_BASE",
+                description="MiniMax global OpenAI-compatible base URL",
+                type="text",
+            ),
+            ProviderParameter(
+                name="MINIMAX_GLOBAL_EN_ANTHROPIC_API_BASE",
+                description="MiniMax global Anthropic-compatible base URL",
+                type="text",
+            ),
+            ProviderParameter(
+                name="MINIMAX_CN_ZH_OPENAI_API_BASE",
+                description="MiniMax China OpenAI-compatible base URL",
+                type="text",
+            ),
+            ProviderParameter(
+                name="MINIMAX_CN_ZH_ANTHROPIC_API_BASE",
+                description="MiniMax China Anthropic-compatible base URL",
+                type="text",
+            ),
+        ],
+    ),
+    ProviderConfig(
         id="cohere",
         name="Cohere",
         description="Cohere's language models",

--- a/backend/pyspur/nodes/llm/_model_info.py
+++ b/backend/pyspur/nodes/llm/_model_info.py
@@ -605,9 +605,9 @@ class LLMModels(str, Enum):
                     input_modalities={"text", "image", "video"},
                     thinking_modes={"adaptive", "disabled"},
                     pricing_usd_per_million_tokens={
-                        "input": 0.3,
-                        "output": 1.2,
-                        "cache_read": 0.06,
+                        "input": 0.6,
+                        "output": 2.4,
+                        "cache_read": 0.12,
                         "cache_write": None,
                     },
                     pricing_tiers_usd_per_million_tokens=[

--- a/backend/pyspur/nodes/llm/_model_info.py
+++ b/backend/pyspur/nodes/llm/_model_info.py
@@ -1,7 +1,7 @@
 from enum import Enum
-from typing import Optional, Set
+from typing import Any, Dict, List, Optional, Set
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from ...utils.mime_types_utils import (
     MIME_TYPES_BY_CATEGORY,
@@ -18,6 +18,7 @@ class LLMProvider(str, Enum):
     AZURE_OPENAI = "azure"
     DEEPSEEK = "deepseek"
     XAI = "xai"
+    MINIMAX = "minimax"
 
 
 class ModelConstraints(BaseModel):
@@ -32,6 +33,11 @@ class ModelConstraints(BaseModel):
     reasoning_separator: str = r"<think>.*?</think>"
     supports_thinking: bool = False
     thinking_budget_tokens: Optional[int] = None
+    context_window: Optional[int] = None
+    input_modalities: Set[str] = Field(default_factory=set)
+    thinking_modes: Set[str] = Field(default_factory=set)
+    pricing_usd_per_million_tokens: Dict[str, Optional[float]] = Field(default_factory=dict)
+    pricing_tiers_usd_per_million_tokens: List[Dict[str, Any]] = Field(default_factory=list)
 
     def add_mime_categories(self, categories: Set[MimeCategory]) -> "ModelConstraints":
         """Add MIME type support for entire categories.
@@ -142,6 +148,10 @@ class LLMModels(str, Enum):
     OLLAMA_MIXTRAL = "ollama/mixtral-8x7b-instruct-v0.1"
 
     XAI_GROK_2 = "xai/grok-2-latest"
+
+    # MiniMax Models
+    MINIMAX_M3 = "minimax/MiniMax-M3"
+    MINIMAX_M2_7 = "minimax/MiniMax-M2.7"
 
     @classmethod
     def get_model_info(cls, model_id: str) -> LLMModel | None:
@@ -582,6 +592,78 @@ class LLMModels(str, Enum):
                             max_tokens=131072,
                             max_temperature=1.0,
                     ),
+            ),
+            cls.MINIMAX_M3.value: LLMModel(
+                id=cls.MINIMAX_M3.value,
+                provider=LLMProvider.MINIMAX,
+                name="MiniMax M3",
+                constraints=ModelConstraints(
+                    max_tokens=65536,
+                    max_temperature=1.0,
+                    supports_thinking=True,
+                    context_window=1000000,
+                    input_modalities={"text", "image", "video"},
+                    thinking_modes={"adaptive", "disabled"},
+                    pricing_usd_per_million_tokens={
+                        "input": 0.3,
+                        "output": 1.2,
+                        "cache_read": 0.06,
+                        "cache_write": None,
+                    },
+                    pricing_tiers_usd_per_million_tokens=[
+                        {
+                            "service_tier": "standard",
+                            "input_tokens_lte": 512000,
+                            "input": 0.3,
+                            "output": 1.2,
+                            "cache_read": 0.06,
+                            "cache_write": None,
+                        },
+                        {
+                            "service_tier": "standard",
+                            "input_tokens_gt": 512000,
+                            "input": 0.6,
+                            "output": 2.4,
+                            "cache_read": 0.12,
+                            "cache_write": None,
+                        },
+                        {
+                            "service_tier": "priority",
+                            "input_tokens_lte": 512000,
+                            "input": 0.45,
+                            "output": 1.8,
+                            "cache_read": 0.09,
+                            "cache_write": None,
+                        },
+                        {
+                            "service_tier": "priority",
+                            "input_tokens_gt": 512000,
+                            "input": 0.9,
+                            "output": 3.6,
+                            "cache_read": 0.18,
+                            "cache_write": None,
+                        },
+                    ],
+                ),
+            ),
+            cls.MINIMAX_M2_7.value: LLMModel(
+                id=cls.MINIMAX_M2_7.value,
+                provider=LLMProvider.MINIMAX,
+                name="MiniMax M2.7",
+                constraints=ModelConstraints(
+                    max_tokens=65536,
+                    max_temperature=1.0,
+                    supports_thinking=True,
+                    context_window=204800,
+                    input_modalities={"text"},
+                    thinking_modes={"always_on"},
+                    pricing_usd_per_million_tokens={
+                        "input": 0.3,
+                        "output": 1.2,
+                        "cache_read": 0.06,
+                        "cache_write": 0.375,
+                    },
+                ),
             ),
         }
         return model_registry.get(model_id)

--- a/backend/pyspur/nodes/llm/_providers.py
+++ b/backend/pyspur/nodes/llm/_providers.py
@@ -4,6 +4,13 @@ from typing import Any, Dict, Optional
 from pydantic import BaseModel, Field
 
 
+MINIMAX_REGIONS = {
+    "global_en": "GLOBAL_EN",
+    "cn_zh": "CN_ZH",
+}
+MINIMAX_PROTOCOLS = {"openai", "anthropic"}
+
+
 class OllamaOptions(BaseModel):
     """Options for Ollama API calls"""
 
@@ -63,3 +70,43 @@ def setup_azure_configuration(kwargs: Dict[str, Any]) -> Dict[str, Any]:
     if missing_config:
         raise ValueError(f"Missing Azure configuration for: {', '.join(missing_config)}")
     return azure_kwargs
+
+
+def setup_minimax_configuration(model: str) -> Dict[str, Any]:
+    """Resolve a MiniMax model to an existing LiteLLM compatible adapter.
+
+    MiniMax exposes both OpenAI-compatible and Anthropic-compatible APIs. The
+    public base URL is selected by region and protocol, while LiteLLM receives
+    the underlying model ID and the matching compatible provider.
+    """
+    if not model.startswith("minimax/"):
+        return {}
+
+    region = os.getenv("MINIMAX_REGION", "global_en")
+    region_key = MINIMAX_REGIONS.get(region)
+    if region_key is None:
+        allowed_regions = ", ".join(sorted(MINIMAX_REGIONS))
+        raise ValueError(f"MINIMAX_REGION must be one of: {allowed_regions}")
+
+    protocol = os.getenv("MINIMAX_PROTOCOL", "openai").lower()
+    if protocol not in MINIMAX_PROTOCOLS:
+        allowed_protocols = ", ".join(sorted(MINIMAX_PROTOCOLS))
+        raise ValueError(f"MINIMAX_PROTOCOL must be one of: {allowed_protocols}")
+
+    env_name = f"MINIMAX_{region_key}_{protocol.upper()}_API_BASE"
+    api_base = os.getenv(env_name, "").rstrip("/")
+    expected_suffix = "/anthropic" if protocol == "anthropic" else "/v1"
+    if not api_base:
+        raise ValueError(f"Missing MiniMax configuration for: {env_name}")
+    if not api_base.endswith(expected_suffix):
+        raise ValueError(f"{env_name} must end with {expected_suffix}")
+
+    request = {
+        "model": model.removeprefix("minimax/"),
+        "custom_llm_provider": protocol,
+        "api_base": api_base,
+    }
+    api_key = os.getenv("MINIMAX_API_KEY")
+    if api_key:
+        request["api_key"] = api_key
+    return request

--- a/backend/pyspur/nodes/llm/_utils.py
+++ b/backend/pyspur/nodes/llm/_utils.py
@@ -19,7 +19,7 @@ from ...utils.file_utils import encode_file_to_base64_data_url
 from ...utils.mime_types_utils import get_mime_type_for_url
 from ...utils.path_utils import is_external_url, resolve_file_path
 from ._model_info import LLMModels
-from ._providers import OllamaOptions, setup_azure_configuration
+from ._providers import OllamaOptions, setup_azure_configuration, setup_minimax_configuration
 
 # uncomment for debugging litellm issues
 # litellm.set_verbose=True
@@ -167,6 +167,10 @@ async def completion_with_backoff(**kwargs) -> Message:
     """
     try:
         model = kwargs.get("model", "")
+        minimax_config = setup_minimax_configuration(model)
+        if minimax_config:
+            kwargs = kwargs.copy()
+            kwargs.update(minimax_config)
         logging.info("=== LLM Request Configuration ===")
         logging.info(f"Requested Model: {model}")
 
@@ -278,6 +282,12 @@ async def generate_text(
 
     # Get model info to check capabilities
     model_info = LLMModels.get_model_info(model_name)
+    litellm_model = model_name
+    litellm_provider = model_info.provider if model_info else None
+    if model_name.startswith("minimax/"):
+        minimax_config = setup_minimax_configuration(model_name)
+        litellm_model = minimax_config["model"]
+        litellm_provider = minimax_config["custom_llm_provider"]
 
     # Only add thinking parameters if explicitly requested and supported by the model
     if thinking and model_info and model_info.constraints.supports_thinking:
@@ -310,11 +320,11 @@ async def generate_text(
 
         # check if the model supports response format
         if "response_format" in litellm.get_supported_openai_params(
-            model=model_name, custom_llm_provider=model_info.provider
+            model=litellm_model, custom_llm_provider=litellm_provider
         ):
             if litellm.supports_response_schema(
-                model=model_name, custom_llm_provider=model_info.provider
-            ) or model_name.startswith("anthropic"):
+                model=litellm_model, custom_llm_provider=litellm_provider
+            ) or litellm_provider == "anthropic":
                 if "name" not in output_json_schema and "schema" not in output_json_schema:
                     output_json_schema = {
                         "schema": output_json_schema,

--- a/backend/tests/test_minimax_provider.py
+++ b/backend/tests/test_minimax_provider.py
@@ -1,0 +1,68 @@
+import os
+from unittest.mock import patch
+
+from pyspur.nodes.llm._model_info import LLMModels
+from pyspur.nodes.llm._providers import setup_minimax_configuration
+
+
+def test_minimax_model_registry_contains_target_models() -> None:
+    m3 = LLMModels.get_model_info(LLMModels.MINIMAX_M3.value)
+    m2_7 = LLMModels.get_model_info(LLMModels.MINIMAX_M2_7.value)
+
+    assert m3 is not None
+    assert m3.constraints.context_window == 1000000
+    assert m3.constraints.input_modalities == {"text", "image", "video"}
+    assert m3.constraints.thinking_modes == {"adaptive", "disabled"}
+    assert m3.constraints.pricing_usd_per_million_tokens["cache_read"] == 0.06
+    assert len(m3.constraints.pricing_tiers_usd_per_million_tokens) == 4
+
+    assert m2_7 is not None
+    assert m2_7.constraints.context_window == 204800
+    assert m2_7.constraints.input_modalities == {"text"}
+    assert m2_7.constraints.thinking_modes == {"always_on"}
+    assert m2_7.constraints.pricing_usd_per_million_tokens["cache_write"] == 0.375
+
+
+def test_minimax_configuration_resolves_all_regions_and_protocols() -> None:
+    environment = {
+        "MINIMAX_GLOBAL_EN_OPENAI_API_BASE": "https://api.minimax.io/v1",
+        "MINIMAX_GLOBAL_EN_ANTHROPIC_API_BASE": "https://api.minimax.io/anthropic",
+        "MINIMAX_CN_ZH_OPENAI_API_BASE": "https://api.minimaxi.com/v1",
+        "MINIMAX_CN_ZH_ANTHROPIC_API_BASE": "https://api.minimaxi.com/anthropic",
+    }
+    cases = [
+        ("global_en", "openai", "https://api.minimax.io/v1"),
+        ("global_en", "anthropic", "https://api.minimax.io/anthropic"),
+        ("cn_zh", "openai", "https://api.minimaxi.com/v1"),
+        ("cn_zh", "anthropic", "https://api.minimaxi.com/anthropic"),
+    ]
+
+    for region, protocol, api_base in cases:
+        with patch.dict(
+            os.environ,
+            {**environment, "MINIMAX_REGION": region, "MINIMAX_PROTOCOL": protocol},
+            clear=False,
+        ):
+            assert setup_minimax_configuration("minimax/MiniMax-M3") == {
+                "model": "MiniMax-M3",
+                "custom_llm_provider": protocol,
+                "api_base": api_base,
+            }
+
+
+def test_minimax_anthropic_base_must_use_anthropic_root() -> None:
+    with patch.dict(
+        os.environ,
+        {
+            "MINIMAX_REGION": "global_en",
+            "MINIMAX_PROTOCOL": "anthropic",
+            "MINIMAX_GLOBAL_EN_ANTHROPIC_API_BASE": "https://api.minimax.io/v1",
+        },
+        clear=False,
+    ):
+        try:
+            setup_minimax_configuration("minimax/MiniMax-M3")
+        except ValueError as exc:
+            assert "must end with /anthropic" in str(exc)
+        else:
+            raise AssertionError("Expected an invalid Anthropic base URL to be rejected")

--- a/backend/tests/test_minimax_provider.py
+++ b/backend/tests/test_minimax_provider.py
@@ -13,7 +13,9 @@ def test_minimax_model_registry_contains_target_models() -> None:
     assert m3.constraints.context_window == 1000000
     assert m3.constraints.input_modalities == {"text", "image", "video"}
     assert m3.constraints.thinking_modes == {"adaptive", "disabled"}
-    assert m3.constraints.pricing_usd_per_million_tokens["cache_read"] == 0.06
+    assert m3.constraints.pricing_usd_per_million_tokens["cache_read"] == 0.12
+    assert m3.constraints.pricing_usd_per_million_tokens["input"] == 0.6
+    assert m3.constraints.pricing_usd_per_million_tokens["output"] == 2.4
     assert len(m3.constraints.pricing_tiers_usd_per_million_tokens) == 4
 
     assert m2_7 is not None

--- a/frontend/src/types/api_types/modelMetadataSchemas.ts
+++ b/frontend/src/types/api_types/modelMetadataSchemas.ts
@@ -20,6 +20,11 @@ export interface ModelConstraints {
     supports_temperature: boolean
     supports_thinking?: boolean
     thinking_budget_tokens?: number
+    context_window?: number
+    input_modalities?: string[]
+    thinking_modes?: string[]
+    pricing_usd_per_million_tokens?: Record<string, number | null>
+    pricing_tiers_usd_per_million_tokens?: Array<Record<string, string | number | null>>
 }
 
 export interface ModelConstraintsMap {


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry.

Summary:
- Add MiniMax M3 and M2.7 to the existing model registry with target context, modality, thinking, and pricing metadata.
- Route MiniMax requests through the existing OpenAI-compatible and Anthropic-compatible LiteLLM adapters with selectable global and China endpoints.
- Expose the provider configuration, example environment variables, frontend metadata fields, and focused tests.

Checks:
- `PYTHONPATH=backend .venv/bin/python -m pytest -q backend/tests/test_minimax_provider.py`
- `.venv/bin/ruff check backend/tests/test_minimax_provider.py`
- `.venv/bin/ruff check --select F backend/pyspur/api/key_management.py backend/pyspur/nodes/llm/_model_info.py backend/pyspur/nodes/llm/_providers.py backend/pyspur/nodes/llm/_utils.py`
- `.venv/bin/python -m py_compile backend/pyspur/api/key_management.py backend/pyspur/nodes/llm/_model_info.py backend/pyspur/nodes/llm/_providers.py backend/pyspur/nodes/llm/_utils.py backend/tests/test_minimax_provider.py`